### PR TITLE
[DOC] README.md 사용방법 수정에 대한 PR입니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ $S = 3P_{fb}^* + 2P_d^* + 1P_t^* + 2I_{fb}^* + 1I_d^*$
 아래 명령어를 통해 CLI를 실행할 수 있습니다.
  
 ```bash
-dotnet run -- repo1 repo2
-dotnet run -- repo1 repo2 --verbose
+dotnet run -- owner repo
+dotnet run -- owner repo --verbose
 dotnet run -- --version
 dotnet run -- --help
 


### PR DESCRIPTION
(https://github.com/oss2025hnu/reposcore-cs/issues/60)  README.md 사용방법 수정

Specify version (commit id).
a305a59796eac9ae1d645fbd758d44e699fedf61

### 변경사항
- 기존 README에서는 `dotnet run -- repo1 repo2` 형식으로 명령어가 안내되어 있었지만,
  실제 프로그램은 `dotnet run -- owner repo` 순서로 인자를 받습니다.
- 프로그램의 동작을 반영하여 사용 방법 및 실행 예시 섹션을 모두 수정하였습니다.
