### PR TITLE
reposcore-cs.sln 파일 Git 추적 대상에서 제외

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ CodeCoverage/
 *.VisualState.xml
 TestResult.xml
 nunit-*.xml
+
+# 솔루션 파일 무시
+reposcore-cs.sln


### PR DESCRIPTION
### ISSUE_ID
#91 

### ISSUE_TITLE
reposcore-cs.sln 파일 gitignore에 추가

###  기준 커밋 (Specify version - commit id)
29ff17b

### 변경사항
- `.gitignore`에 `reposcore-cs.sln` 추가
- Git에서 해당 파일을 인덱스에서 제거 (`git rm --cached` 사용)

### 💬 참고 사항 (선택 사항)
- Visual Studio 또는 Codespaces 환경에서 자동 생성된 파일일 가능성 있음
- 개발 편의를 위해 명시적으로 무시 목록에 추가
