### PR TITLE
Program.cs 순서 변경

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -9,13 +9,6 @@ CoconaApp.Run((
     [Option("f|format", Description = "출력 형식을 지정합니다.")] string? format  // --format 옵션
 ) =>
 {
-    Console.WriteLine($"Repository: {String.Join("\n ", repos)}");
-
-    if (verbose)
-    {
-        Console.WriteLine("Verbose mode is enabled.");
-    }
-
     if (repos.Length != 2)
     {
         Console.WriteLine("❗ repository 인자는 'owner repo' 순서로 2개가 필요합니다.");
@@ -25,6 +18,13 @@ CoconaApp.Run((
 
     string owner = repos[0];
     string repo = repos[1];
+    
+    Console.WriteLine($"Repository: {String.Join("\n ", repos)}");
+
+    if (verbose)
+    {
+        Console.WriteLine("Verbose mode is enabled.");
+    }
 
     try
     {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/108

### ISSUE_TITLE
[BUG] program.cs에서 if (repos.Length != 2) 유효성 검사의 순서변

###  기준 커밋 (Specify version - commit id)
b5cb53d

### 변경사항
유효성 검사를 Console.WriteLine($"Repository: {String.Join("\n ", repos)}"); 이전으로 순서를 변경했습니다.
