### PR TITLE
빈파일 생성 관련 pr

### DIFF
--- a/GitHubAnalyzer.cs
+++ b/GitHubAnalyzer.cs
@@ -1,24 +1,22 @@
 using Octokit;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 public class GitHubAnalyzer
 {
     private readonly GitHubClient _client;
 
-    // GitHubClient를 초기화하고, 사용자로부터 입력받은 GitHub 토큰을 인증에 사용합니다.
     public GitHubAnalyzer(string token)
     {
         _client = CreateClient("reposcore-cs", token);
     }
 
-    // GitHubClient를 생성하고, 인증 정보를 설정합니다.
     private GitHubClient CreateClient(string productName, string token)
     {
         var client = new GitHubClient(new ProductHeaderValue(productName));
 
-        // 인증이 제공된 경우, 사용자 토큰을 사용하여 인증
         if (!string.IsNullOrEmpty(token))
         {
             client.Credentials = new Credentials(token);
@@ -27,41 +25,32 @@ public class GitHubAnalyzer
         return client;
     }
 
-    // 예외를 처리하는 메서드로, 오류 메시지를 출력하고 프로그램을 종료합니다.
     private void HandleError(Exception ex)
     {
         Console.WriteLine($"❗ 알 수 없는 오류가 발생했습니다: {ex.Message}");
         Environment.Exit(1);
     }
 
-    // GitHub 저장소에서 PR(Pull Request) 및 Issue 정보를 분석하는 메서드
-    public void Analyze(string owner, string repo)
+    public void Analyze(string owner, string repo, string outputDir, List<string> formats)
     {
         try
         {
-            // 1. 병합된 PR(Closed 상태인 PR) 목록을 가져옵니다.
             var prs = _client.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest
             {
                 State = ItemStateFilter.Closed
-            }).Result;  // 비동기 호출을 동기적으로 처리
+            }).Result;
 
-            // 2. 모든 이슈(열린 상태와 닫힌 상태 모두) 목록을 가져옵니다.
             var issues = _client.Issue.GetAllForRepository(owner, repo, new RepositoryIssueRequest
             {
                 State = ItemStateFilter.All
             }).Result;
 
-            // 3. 'bug', 'documentation', 'enhancement' 레이블에 대한 카운트를 셀 딕셔너리 초기화
             var targetLabels = new[] { "bug", "documentation", "enhancement" };
             var labelCounts = targetLabels.ToDictionary(label => label, _ => 0);
 
-            // 4. PR 중에서 병합된 PR만 필터링하여 레이블을 분석합니다.
             foreach (var pr in prs.Where(p => p.Merged == true))
             {
-                // PR의 레이블을 소문자로 변환하여 리스트로 만듦
                 var labels = pr.Labels.Select(l => l.Name.ToLower()).ToList();
-
-                // 지정된 레이블이 PR의 레이블에 포함되어 있으면 카운트 증가
                 foreach (var label in targetLabels)
                 {
                     if (labels.Contains(label))
@@ -69,15 +58,10 @@ public class GitHubAnalyzer
                 }
             }
 
-            // 5. Issue 중에서 PR에 속하지 않은(즉, PR에서 파생되지 않은) 이슈들을 분석
             foreach (var issue in issues)
             {
-                if (issue.PullRequest != null) continue;  // PR에 속하는 이슈는 건너뜁니다.
-
-                // 이슈의 레이블을 소문자로 변환하여 리스트로 만듦
+                if (issue.PullRequest != null) continue;
                 var labels = issue.Labels.Select(l => l.Name.ToLower()).ToList();
-
-                // 지정된 레이블이 이슈의 레이블에 포함되어 있으면 카운트 증가
                 foreach (var label in targetLabels)
                 {
                     if (labels.Contains(label))
@@ -85,45 +69,63 @@ public class GitHubAnalyzer
                 }
             }
 
-            // 6. 결과 출력
             Console.WriteLine("\n📊 GitHub Label 통계 결과");
 
             Console.WriteLine("\n✅ Pull Requests (Merged)");
-            // 'bug', 'documentation', 'enhancement' 레이블에 대해 분석된 PR 수 출력
             foreach (var label in targetLabels)
             {
                 Console.WriteLine($"- {char.ToUpper(label[0]) + label.Substring(1)} PRs: {labelCounts[label]}");
             }
 
             Console.WriteLine("\n✅ Issues");
-            // 'bug', 'documentation', 'enhancement' 레이블에 대해 분석된 Issue 수 출력
             foreach (var label in targetLabels)
             {
                 Console.WriteLine($"- {char.ToUpper(label[0]) + label.Substring(1)} Issues: {labelCounts[label]}");
             }
+
+            // 출력 디렉토리에 포맷별 빈 파일 생성
+            GenerateOutputFiles(outputDir, formats);
         }
         catch (RateLimitExceededException)
         {
-            // Rate Limit 초과시 메시지 출력
             Console.WriteLine("❗ API 호출 한도(Rate Limit)를 초과했습니다. 잠시 후 다시 시도해주세요.");
-            Environment.Exit(1);  // 프로그램 종료
+            Environment.Exit(1);
         }
         catch (AuthorizationException)
         {
-            // 인증 오류 발생 시 메시지 출력
             Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
-            Environment.Exit(1);  // 프로그램 종료
+            Environment.Exit(1);
         }
         catch (NotFoundException)
         {
-            // 저장소를 찾을 수 없을 때 메시지 출력
             Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
-            Environment.Exit(1);  // 프로그램 종료
+            Environment.Exit(1);
         }
         catch (Exception ex)
         {
-            // 그 외의 모든 예외를 처리하는 부분
             HandleError(ex);
+        }
+    }
+
+    // format 옵션에 따라 빈 파일을 생성하는 메서드
+    private void GenerateOutputFiles(string outputDir, List<string> formats)
+    {
+        try
+        {
+            Directory.CreateDirectory(outputDir); // 디렉토리 생성
+
+            foreach (var format in formats)
+            {
+                string fileName = $"result.{format.ToLower()}";
+                string filePath = Path.Combine(outputDir, fileName);
+
+                File.WriteAllText(filePath, string.Empty); // 빈 파일 생성
+                Console.WriteLine($"📁 생성된 파일: {filePath}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❗ 출력 파일 생성 중 오류: {ex.Message}");
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,26 +1,27 @@
 ﻿using Cocona;
 using System;
+using System.Collections.Generic;
 using Octokit;
 
 CoconaApp.Run((
     [Argument] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
     [Option("o|output", Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
-    [Option("f|format", Description = "출력 형식을 지정합니다.")] string? format,
-    [Option('t', Description = "GitHub Personal Access Token 입력")] string? token // 토큰 입력 옵션 추가
+    [Option("f|format", Description = "출력 형식을 지정합니다. (예: json,csv)")] string? format,
+    [Option('t', Description = "GitHub Personal Access Token 입력")] string? token
 ) =>
 {
     if (repos.Length != 2)
     {
         Console.WriteLine("! repository 인자는 'owner repo' 순서로 2개가 필요합니다.");
-        Environment.Exit(1);  // 오류 발생 시 exit code 1로 종료
+        Environment.Exit(1);
         return;
     }
 
     string owner = repos[0];
     string repo = repos[1];
     
-    Console.WriteLine($"Repository: {String.Join("\n ", repos)}");
+    Console.WriteLine($"Repository: {string.Join("\n ", repos)}");
 
     if (verbose)
     {
@@ -31,16 +32,13 @@ CoconaApp.Run((
     {
         var client = new GitHubClient(new ProductHeaderValue("CoconaApp"));
 
-        // GitHub Personal Access Token이 입력되었으면 인증 설정
         if (!string.IsNullOrEmpty(token))
         {
             client.Credentials = new Credentials(token);
         }
 
-        // Repository 정보 가져오기
         var repository = client.Repository.Get(owner, repo).GetAwaiter().GetResult();
 
-        // Repository에 대한 기본 정보 출력
         Console.WriteLine($"[INFO] Repository Name: {repository.Name}");
         Console.WriteLine($"[INFO] Full Name: {repository.FullName}");
         Console.WriteLine($"[INFO] Description: {repository.Description}");
@@ -49,7 +47,6 @@ CoconaApp.Run((
         Console.WriteLine($"[INFO] Open Issues: {repository.OpenIssuesCount}");
         Console.WriteLine($"[INFO] Language: {repository.Language}");
         Console.WriteLine($"[INFO] URL: {repository.HtmlUrl}");
-
     }
     catch (Exception e)
     {
@@ -59,15 +56,22 @@ CoconaApp.Run((
 
     try
     {
-        // GitHubAnalyzer 사용 (주석 해제)
-        var analyzer = new GitHubAnalyzer(token); // 토큰을 전달
-        analyzer.Analyze(repos[0], repos[1]);   // PR과 이슈 분석을 실행
+        // format 옵션을 쉼표로 분리하여 리스트로 변환
+        var formats = string.IsNullOrWhiteSpace(format)
+            ? new List<string> { "json" }
+            : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
+
+        // 출력 디렉토리 기본값 처리
+        var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
+
+        var analyzer = new GitHubAnalyzer(token);
+        analyzer.Analyze(owner, repo, outputDir, formats); // 변경된 Analyze 호출
     }
     catch (Exception ex)
     {
         Console.WriteLine($"! 오류 발생: {ex.Message}");
-        Environment.Exit(1);  // 예외 발생 시 exit code 1로 종료
+        Environment.Exit(1);
     }
 
-    Environment.Exit(0);  // 정상 종료 시 exit code 0으로 종료
+    Environment.Exit(0);
 });

--- a/Program.cs
+++ b/Program.cs
@@ -6,8 +6,8 @@ using Octokit;
 CoconaApp.Run((
     [Argument] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
-    [Option("o|output", Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
-    [Option("f|format", Description = "출력 형식을 지정합니다. (예: json,csv)")] string? format,
+    [Option('o', Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
+    [Option('f', Description = "출력 형식을 지정합니다. (예: json,csv)")] string? format,
     [Option('t', Description = "GitHub Personal Access Token 입력")] string? token
 ) =>
 {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/92

### ISSUE_TITLE
옵션 기능 구현

###  기준 커밋 (Specify version - commit id)
bd4f325e93923dcc6c424cf58285f711e0cd497c

### 변경사항
GitHubAnalyzer.Analyze() 메서드에 outputDir, formats 인자 추가
분석 후 지정된 디렉토리에 result.{확장자} 형태의 빈 출력 파일 생성 기능 구현
Program.cs에서 --output, --format 옵션을 받아 Analyze()에 전달하도록 수정
기본값 지정: 옵션 미입력 시 output/, json 파일 생성

### 🧪 테스트 방법 (선택 사항)
dotnet run -- octocat Hello-World -t ghp_유효한토큰 -o output -f json,csv -v
실행 결과:
콘솔에 저장소 정보와 라벨 분석 통계 출력 확인
output/ 디렉토리에 result.json, result.csv 빈 파일 생성 여부 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
