### PR TITLE
CS8604 nullable 경고 제거를 위한 token! 연산자 적용

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,7 @@ CoconaApp.Run((
 
     string owner = repos[0];
     string repo = repos[1];
-    
+
     Console.WriteLine($"Repository: {string.Join("\n ", repos)}");
 
     if (verbose)
@@ -56,16 +56,14 @@ CoconaApp.Run((
 
     try
     {
-        // format 옵션을 쉼표로 분리하여 리스트로 변환
         var formats = string.IsNullOrWhiteSpace(format)
             ? new List<string> { "json" }
             : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
 
-        // 출력 디렉토리 기본값 처리
         var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
 
-        var analyzer = new GitHubAnalyzer(token);
-        analyzer.Analyze(owner, repo, outputDir, formats); // 변경된 Analyze 호출
+        var analyzer = new GitHubAnalyzer(token!); // ✅ null-forgiving 연산자 적용
+        analyzer.Analyze(owner, repo, outputDir, formats);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/144 는 중복된 이슈이므로 이 PR은 다음 이슈에 대한 것으로 취급합니다.

- https://github.com/oss2025hnu/reposcore-cs/issues/121

### ISSUE_TITLE
GitHubAnalyzer 생성자 호출 시 nullable 경고 제거

###  기준 커밋 (Specify version - commit id)
44e65bc38f1199e9ef9585159ba47e29747ff785

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- GitHubAnalyzer 생성자 호출 시 `token!` (null-forgiving 연산자) 적용
- `Program.cs` 내 CS8604 경고 제거
- 기존 인증 흐름에는 영향 없이 정적 분석 안정성 향상


### 🧪 테스트 방법 (선택 사항)
`dotnet build` 실행 시 CS8604 경고가 사라졌는지 확인

