### PR TITLE
파일 생성 시 유효하지 않은 파일 이름에 대한 오류 메시지 개선

### DIFF
--- a/Reposcore/GitHubAnalyzer.cs
+++ b/Reposcore/GitHubAnalyzer.cs
@@ -117,6 +117,13 @@ public class GitHubAnalyzer
 
             foreach (var format in formats)
             {
+                // 파일 이름으로 유효한 문자만 사용되었는지 확인
+                if (format.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+                {
+                    Console.WriteLine($"❗ 출력 형식 '{format}'에 유효하지 않은 문자가 포함되어 있어 파일을 생성할 수 없습니다.");
+                    Environment.Exit(1);
+                }
+
                 string fileName = $"result.{format.ToLower()}";
                 string filePath = Path.Combine(outputDir, fileName);
 


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/142

### ISSUE_TITLE
파일 생성 시 유효하지 않은 파일 이름에 대한 오류 메시지 개선

###  기준 커밋 (Specify version - commit id)
7249379c571fec79b50f9e1fe1a74397a697c539

### 변경사항
- 출력 포맷(--format)에 유효하지 않은 문자가 포함된 경우 탐지
- 사용자에게 친절한 오류 메시지 출력
- 프로그램이 exit code 1로 명확히 종료되도록 개선


### 🧪 테스트 방법 (선택 사항)
- format 옵션에 inva:lid, json 등 유효하지 않은 파일명 포함 시 오류 메시지 출력 후 종료되는지 확인
- Linux에선 허용되는 문자도 있지만, Windows 기준 테스트 시 IO 오류 방지 확인

### 💬 참고 사항 (선택 사항)
<!-- 리뷰 시 참고해야 할 내용이나 전달하고 싶은 사항이 있다면 작성해주세요 -->
