### PR TITLE
[DOC] .NET Guide 문서에 명령어 실행 결과 예시 추가 요청

### DIFF
--- a/docs/dotNet-guide.md
+++ b/docs/dotNet-guide.md
@@ -23,28 +23,78 @@ dotnet new console -n {프로젝트_이름}
 
 ## 프로젝트 빌드
 
+프로젝트의 C# 코드를 컴파일하여 실행 가능한 `.dll` 파일을 생성합니다.
+컴파일 오류를 사전에 확인하거나, 실행 파일을 따로 만들고자 할 때 사용됩니다.
+
 ```bash
 dotnet build
 ```
 
+예시 출력:
+```bash
+Build succeeded.
+    0 Warning(s)
+    0 Error(s)
+```
 빌드 결과물은 `bin/` 폴더에 생성됩니다.
 
 ---
 
 ## 프로젝트 실행
 
+프로젝트를 자동으로 빌드한 뒤 `Program.cs`의 `Main` 메서드를 실행합니다.
+입력 인자가 필요한 프로그램이라면 `--` 뒤에 인자를 넣어줘야 합니다.
+
 ```bash
-dotnet run
+dotnet run -- [owner] [repo]
 ```
 
+예시 (reposcore-cs 실행):
+```bash
+dotnet run -- oss2025hnu reposcore-cs
+```
+
+예시 출력:
+```bash
+📊 GitHub Label 통계 결과
+
+✅ Pull Requests (Merged)
+- Bug PRs: 8
+- Documentation PRs: 62
+- Enhancement PRs: 57
+
+✅ Issues
+- Bug Issues: 8
+- Documentation Issues: 62
+- Enhancement Issues: 57
+
 `Program.cs`의 `Main` 메서드가 실행됩니다.
+```
 
 ---
 
 ## 테스트
 
+`xUnit`, `NUnit`, `MSTest` 등으로 작성된 테스트 코드를 실행합니다.
+현재 이 저장소는 테스트 프로젝트가 없어 실행 가능한 테스트가 없습니다.
+
 ```bash
 dotnet test
+```
+
+예시 출력: (현재 테스트 프로젝트 없음)
+```bash
+Determining projects to restore...
+All projects are up-to-date for restore.
+```
+
+예시 출력: (테스트 프로젝트 1개 존재 시)
+```bash
+Test run for /reposcore-cs.Tests/bin/Debug/net8.0/reposcore-cs.Tests.dll (.NETCoreApp,Version=v8.0)
+Microsoft (R) Test Execution Command Line Tool Version 17.8.0
+
+Starting test execution, please wait...
+Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 23 ms
 ```
 
 > 테스트 프로젝트(`xUnit`, `NUnit` 등)가 존재할 경우 실행됩니다.  


### PR DESCRIPTION
### ISSUE_ID
<!-- 관련된 이슈 ID를 입력해주세요 (예: #123) -->
#165 

### ISSUE_TITLE
<!-- 관련된 이슈 제목을 입력해주세요 -->
[DOC] .NET Guide 문서에 명령어 실행 결과 예시 추가 요청

###  기준 커밋 (Specify version - commit id)
<!-- 변경 사항이 반영된 기준 커밋 ID를 입력해주세요 (예: 0e34a8b) -->
43856091316afaa1dfbc6b3c8654a3707ba6490f

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 : `dotnet-guide.md` 문서에 다음 명령어별 실행 예시 및 설명 추가:
`dotnet build` : 기본 출력 예시와 설명
`dotnet run` : 입력 인자 예시 및 실제 출력 예시와 설명 (reposcore-cs 기준)
`dotnet test` : 테스트 프로젝트가 없을 경우, 있을 경우 각각의 출력 예시와 설명