### PR TITLE
output 옵션 내용 정리

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -61,7 +61,7 @@ CoconaApp.Run((
             : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
 
         var analyzer = new GitHubAnalyzer(token!); // ✅ null-forgiving 연산자 적용
-        analyzer.Analyze(owner, repo, output, formats);
+        analyzer.Analyze(owner, repo, output, formats); // outputDir에서 output으로 수정
     }
     catch (Exception ex)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -6,9 +6,9 @@ using Octokit;
 CoconaApp.Run((
     [Argument] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
-    [Option('o', Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
-    [Option('f', Description = "출력 형식을 지정합니다. (예: json,csv)")] string? format,
-    [Option('t', Description = "GitHub Personal Access Token 입력")] string? token
+    [Option('t', Description = "GitHub Personal Access Token 입력")] string? token,
+    [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (기본값: output)")] string output = "output",
+    [Option('f', Description = "출력 형식을 지정합니다. (기본값: json)")] string format = "json"
 ) =>
 {
     if (repos.Length != 2)
@@ -60,10 +60,8 @@ CoconaApp.Run((
             ? new List<string> { "json" }
             : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
 
-        var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
-
         var analyzer = new GitHubAnalyzer(token!); // ✅ null-forgiving 연산자 적용
-        analyzer.Analyze(owner, repo, outputDir, formats);
+        analyzer.Analyze(owner, repo, output, formats);
     }
     catch (Exception ex)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -67,7 +67,7 @@ CoconaApp.Run((
             : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
 
         var analyzer = new GitHubAnalyzer(token!); // ✅ null-forgiving 연산자 적용
-        analyzer.Analyze(owner, repo, output, formats); // outputDir에서 output으로 수정
+        analyzer.Analyze(owner, repo, output, formats);
 
     }
     catch (Exception ex)

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using Cocona;
+using Cocona;
 using System;
 using System.Collections.Generic;
 using Octokit;
@@ -11,12 +11,6 @@ CoconaApp.Run((
     [Option('f', Description = "출력 형식을 지정합니다. (기본값: json)")] string format = "json"
 ) =>
 {
-    // 더미 데이타가 실제로 불러와 지는지 기본적으로 확인하기 위한 코드
-    var repo1Activities = DummyData.repo1Activities;
-    Console.WriteLine("repo1Activities:"+repo1Activities.Count);
-    var repo2Activities = DummyData.repo2Activities;
-    Console.WriteLine("repo2Activities:"+repo2Activities.Count);
-
     if (repos.Length != 2)
     {
         Console.WriteLine("! repository 인자는 'owner repo' 순서로 2개가 필요합니다.");
@@ -68,7 +62,6 @@ CoconaApp.Run((
 
         var analyzer = new GitHubAnalyzer(token!); // ✅ null-forgiving 연산자 적용
         analyzer.Analyze(owner, repo, output, formats);
-
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
### ISSUE_ID
#177

### ISSUE_TITLE
--output 옵션 내용 정리가 필요합니다

###  기준 커밋 (Specify version - commit id)
200fb5b6693a1515e2a26faa876ccbcf76d1a525

### 변경사항
-  `--output` 옵션에 기본값을 Cocona 옵션 선언부에서 직접 지정하도록 수정 (`output = "output"`)
-  기존 코드의 `string.IsNullOrWhiteSpace(output)` 조건 처리 로직 제거
- `--help` 출력 시 `--output`의 기본값이 자동으로 명시되도록 개선

before)
![스크린샷 2025-05-21 163107](https://github.com/user-attachments/assets/217fc928-97b0-4da6-9f65-7bf2ea5438fa)

after)
![스크린샷 2025-05-21 163054](https://github.com/user-attachments/assets/e561caf1-1da6-439c-802a-4f7e965a783c)

### 💬 참고 사항
```bash 
var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
analyzer.Analyze(owner, repo, outputDir, formats)
``` 
위 코드 삭제 및 변경이유
Cocona 옵션 선언부에서 기본값 "output"을 지정하면 `output`이 null이 될 일이 없기 때문에, outputDir 조건문은 필요하지 않습니다.
중간 변수를 없애고 output을 바로 사용하면 코드가 더 간결하고 명확해집니다. 또한 --help 실행 시 기본값이 자동으로 표시되어, 사용자에게 더 직관적인 CLI 환경을 제공합니다.
