### PR TITLE
[FEAT] 점수 계산 전담 ScoreCalculator 클래스 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $S = 3P_{fb}^* + 2P_d^* + 1P_t^* + 2I_{fb}^* + 1I_d^*$
 ##  C# Dev Kit 설치 및 활용
 Visual Studio Code용 C# Dev Kit 확장 프로그램은 C# 개발을 보다 편리하게 도와주는 도구입니다.  
 테스트 실행, 디버깅, IntelliSense 자동완성 기능을 지원합니다.
-이 확장은 .NET 기반 C# 콘솔 애플리케이션, Blazor, MAUI 등 다양한 .NET 프로젝트;
+이 확장은 .NET 기반 C# 콘솔 애플리케이션, Blaㅏㄴㅌzor, MAUI 등 다양한 .NET 프로젝트;
 xUnit, NUnit, MSTest 등 테스트 프레임워크; Windows, macOS, Linux 플랫폼을 지원합니다.
 
 ### 설치 방법

--- a/Reposcore/ScoreCalulator.cs
+++ b/Reposcore/ScoreCalulator.cs
@@ -1,0 +1,47 @@
+namespace Reposcore
+{
+    public record ScoreComponents(
+        int FeaturePR,
+        int BugfixPR,
+        int DocsPR,
+        int TypoPR,
+        int FeatureIssue,
+        int DocsIssue
+    );
+}
+
+namespace Reposcore
+{
+    public static class ScoreCalculator
+    {
+        public static int CalculateTotalScore(ScoreComponents components)
+        {
+            int score = 0;
+
+            score += components.FeaturePR * 3;
+            score += components.BugfixPR * 3;
+            score += components.DocsPR * 2;
+            score += components.TypoPR * 1;
+            score += components.FeatureIssue * 2;
+            score += components.DocsIssue * 1;
+
+            return score;
+        }
+
+        public static int CalculateValidPRCount(ScoreComponents components)
+        {
+            int contentPRs = components.FeaturePR + components.BugfixPR;
+            int supportPRs = components.DocsPR + components.TypoPR;
+
+            return components.FeaturePR + Math.Min(supportPRs, 3 * Math.Max(components.FeaturePR, 1));
+        }
+
+        public static int CalculateValidIssueCount(ScoreComponents components)
+        {
+            int validPR = CalculateValidPRCount(components);
+            int issueSum = components.FeatureIssue + components.DocsIssue;
+
+            return Math.Min(issueSum, 4 * validPR);
+        }
+    }
+}

--- a/Reposcore/ScoreCalulator.cs
+++ b/Reposcore/ScoreCalulator.cs
@@ -1,47 +1,41 @@
-namespace Reposcore
-{
-    public record ScoreComponents(
-        int FeaturePR,
-        int BugfixPR,
-        int DocsPR,
-        int TypoPR,
-        int FeatureIssue,
-        int DocsIssue
-    );
-}
+public record ScoreComponents(
+    int FeaturePR,
+    int BugfixPR,
+    int DocsPR,
+    int TypoPR,
+    int FeatureIssue,
+    int DocsIssue
+);
 
-namespace Reposcore
+public static class ScoreCalculator
 {
-    public static class ScoreCalculator
+    public static int CalculateTotalScore(ScoreComponents components)
     {
-        public static int CalculateTotalScore(ScoreComponents components)
-        {
-            int score = 0;
+        int score = 0;
 
-            score += components.FeaturePR * 3;
-            score += components.BugfixPR * 3;
-            score += components.DocsPR * 2;
-            score += components.TypoPR * 1;
-            score += components.FeatureIssue * 2;
-            score += components.DocsIssue * 1;
+        score += components.FeaturePR * 3;
+        score += components.BugfixPR * 3;
+        score += components.DocsPR * 2;
+        score += components.TypoPR * 1;
+        score += components.FeatureIssue * 2;
+        score += components.DocsIssue * 1;
 
-            return score;
-        }
+        return score;
+    }
 
-        public static int CalculateValidPRCount(ScoreComponents components)
-        {
-            int contentPRs = components.FeaturePR + components.BugfixPR;
-            int supportPRs = components.DocsPR + components.TypoPR;
+    public static int CalculateValidPRCount(ScoreComponents components)
+    {
+        int contentPRs = components.FeaturePR + components.BugfixPR;
+        int supportPRs = components.DocsPR + components.TypoPR;
 
-            return components.FeaturePR + Math.Min(supportPRs, 3 * Math.Max(components.FeaturePR, 1));
-        }
+        return components.FeaturePR + Math.Min(supportPRs, 3 * Math.Max(components.FeaturePR, 1));
+    }
 
-        public static int CalculateValidIssueCount(ScoreComponents components)
-        {
-            int validPR = CalculateValidPRCount(components);
-            int issueSum = components.FeatureIssue + components.DocsIssue;
+    public static int CalculateValidIssueCount(ScoreComponents components)
+    {
+        int validPR = CalculateValidPRCount(components);
+        int issueSum = components.FeatureIssue + components.DocsIssue;
 
-            return Math.Min(issueSum, 4 * validPR);
-        }
+        return Math.Min(issueSum, 4 * validPR);
     }
 }


### PR DESCRIPTION
### ISSUE_ID
#173

### ISSUE_TITLE
점수 계산 전용 ScoreCalculator 클래스 분리 

###  기준 커밋 (Specify version - commit id)
66984384b08b3f14737ed3ed7a6eca3341475307

### 변경사항
- `ScoreCalculator` 클래스를 별도로 분리하여 점수 계산만 전담하도록 구현하였습니다.
- PR/이슈 항목별 raw count를 입력으로 받아 유효 개수 계산, 항목 조정, 최종 점수를 산출합니다.