### PR TITLE
--format 옵션 정리 및 필터링 기능 구현

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -6,9 +6,9 @@ using Octokit;
 CoconaApp.Run((
     [Argument] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
+    [Option('o', Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
     [Option('t', Description = "GitHub Personal Access Token 입력")] string? token,
-    [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (기본값: output)")] string output = "output",
-    [Option('f', Description = "출력 형식을 지정합니다. (기본값: table)")] string format = "table"
+    [Option('f', Description = "출력 형식을 지정합니다. (text, csv, chart, html, all)")] string format = "all"
 ) =>
 {
     // 더미 데이타가 실제로 불러와 지는지 기본적으로 확인하기 위한 코드
@@ -62,14 +62,21 @@ CoconaApp.Run((
 
     try
     {
-        var formats = string.IsNullOrWhiteSpace(format)
-            ? new List<string> { "table" }
-            : new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries));
+        var formats = getValidFormat(format);
 
         var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
 
         var dataCollector = new RepoDataCollector(token!); // ✅ null-forgiving 연산자 적용
         dataCollector.Collect(owner, repo, outputDir, formats);
+
+        // ===== 파일 생성 기능 구현 후 제거 =====
+        Console.WriteLine("\n===생성되는 포맷===");
+        foreach (var fm in formats)
+        {
+            Console.WriteLine($"-{fm}");
+        }
+        Console.WriteLine("\n파일 생성 기능이 아직 구현되지 않았습니다.");
+        // ===== 파일 생성 기능 구현 후 제거 =====
     }
     catch (Exception ex)
     {
@@ -79,3 +86,46 @@ CoconaApp.Run((
 
     Environment.Exit(0);
 });
+
+static List<string> getValidFormat(string format) 
+{   
+    var formats = new List<string>(format.Split(',', StringSplitOptions.RemoveEmptyEntries)); 
+    var FormatList = new List<string> {"text", "csv", "chart", "html", "all"}; // 유효한 format
+
+    var validFormats = new List<string> { };
+    var unValidFormats = new List<string> { };
+
+    foreach (var fm in formats)
+    {
+        if (FormatList.Contains(fm)) validFormats.Add(fm);
+        else unValidFormats.Add(fm);
+    }
+
+    // 유효하지 않은 포맷이 존재
+    if (unValidFormats.Count != 0)
+    {   
+        Console.WriteLine("유효하지 않은 포맷이 존재합니다.");
+        Console.Write("유효하지 않은 포맷: ");
+        foreach (var unValidFormat in unValidFormats)
+        {
+            Console.Write($"{unValidFormat} ");
+        }
+        Console.Write("\n");
+    }
+
+    // 유효한 포맷이 존재 X
+    if (validFormats.Count == 0)
+    {
+        Console.WriteLine("유효한 포맷이 존재하지 않습니다.");
+        Console.WriteLine("모든 포맷을 생성합니다.");
+        validFormats.Add("all");
+    }
+
+    // 추출한 리스트에에 "all"이 존재할 경우 모든 포맷 리스트 반환
+    if (validFormats.Contains("all"))
+    {
+        return new List<string> { "text", "csv", "chart", "html" };
+    }
+
+    return validFormats;
+}


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/179

### ISSUE_TITLE
[REFACTOR] --format 옵션에서 중복되는 포맷 정리 제안

###  기준 커밋 (Specify version - commit id)
9793d8f30d448dfe0928523534a11cccdd5cfc3d

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1
기존 csv, json만 존재하던 --format 옵션에서 json을 제외 후,  csv, text, chart, html, all로 변경하였습니다. 
기본값은 all로 설정하였습니다.
- [ ] 변경 사항 2
`dotnet run -- oss2025hnu reposcore-cs -f text,csv,chart` 와 같이 쉼표를 구분자로 전달받은 문자열을 리스트로 변경하여 반환하는 `getValidFormat` 함수를 구현하였습니다.
`dotnet run -- oss2025hnu reposcore-cs -f text,csv,json`  와 같이 유효하지 않은 포맷 입력시 유효하지 않은 포맷이 입력되었음을 출력하고, 해당 옵션을 제외한 포맷들만을 반환합니다.
`dotnet run -- oss2025hnu reposcore-cs -f a,b` 와 같이 유효한 포맷이 존재하지 않을 경우, 이를 알린 후 모든 포맷을 반환합니다.
- [ ] 변경 사항 3
파일 생성 단계 시, `GenerateOutputFiles` 함수가 아직 구현되지 않았으므로 "파일 생성 기능이 아직 구현되지 않았습니다." 를 출력 후, 기능이 구현되었다면 생성되어야 할 파일들의 형식들을 출력합니다. 해당 출력은 파일 생성 기능의 구현 후 삭제되어야 합니다.

### 🧪 테스트 방법 (선택 사항)
`dotnet run -- oss2025hnu reposcore-cs` -> 모든 파일 생성
`dotnet run -- oss2025hnu reposcore-cs -f csv,text` -> csv, txt 파일 생성
`dotnet run -- oss2025hnu reposcore-cs -f csv,json` -> csv 파일 생성
