### PR TITLE
--format 옵션 유효성 검사 및 최신 포맷 기준 적용

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using Cocona;
+using Cocona;
 using System;
 using System.Collections.Generic;
 using Octokit;
@@ -97,8 +97,9 @@ static List<string> getValidFormat(string format)
 
     foreach (var fm in formats)
     {
-        if (FormatList.Contains(fm)) validFormats.Add(fm);
-        else unValidFormats.Add(fm);
+        var f = fm.Trim().ToLowerInvariant(); // 대소문자 구분 없이 유효성 검사
+        if (FormatList.Contains(f)) validFormats.Add(f);
+        else unValidFormats.Add(f);
     }
 
     // 유효하지 않은 포맷이 존재
@@ -118,7 +119,7 @@ static List<string> getValidFormat(string format)
     {
         Console.WriteLine("유효한 포맷이 존재하지 않습니다.");
         Console.WriteLine("모든 포맷을 생성합니다.");
-        validFormats.Add("all");
+        return new List<string> { "csv", "text", "chart", "html" };
     }
 
     // 추출한 리스트에에 "all"이 존재할 경우 모든 포맷 리스트 반환


### PR DESCRIPTION
### ISSUE_ID
#141

### ISSUE_TITLE
잘못된 옵션 입력 시 유효성 검사 및 경고 메시지 추가

###  기준 커밋 (Specify version - commit id)
4c06b9754c75248a8c4109119aecd9e371797ebc

### 변경사항
- [x] --format 옵션 입력값에 대해 쉼표로 구분된 문자열을 파싱하고 유효성 검사 수행
- [x] json 포맷 제거 및 허용 포맷을 text, csv, chart, html, all 로 제한
- [x] 유효하지 않은 포맷 입력 시 경고 메시지를 출력하고 해당 포맷은 제외
- [x] 유효한 포맷이 전혀 없을 경우 전체 포맷(all)로 자동 대체

### 🧪 테스트 방법
```bash
dotnet run -- owner repo --format csv,json
# 출력: 유효하지 않은 포맷: json