### PR TITLE
.env파일을 활용한 GitHub 토큰 관리 자동화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ nunit-*.xml
 
 # 솔루션 파일 무시
 reposcore-cs.sln
+
+#env파일
+.env

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using Octokit;
+using DotNetEnv;
 
 CoconaApp.Run((
     [Argument] string[] repos,
@@ -39,7 +40,16 @@ CoconaApp.Run((
         var client = new GitHubClient(new ProductHeaderValue("CoconaApp"));
 
         if (!string.IsNullOrEmpty(token))
-        {
+        {   
+            File.WriteAllText(".env", $"GITHUB_TOKEN={token}\n");
+            Console.WriteLine(".env의 토큰을 갱신합니다.");
+            client.Credentials = new Credentials(token);
+        }
+        else if (File.Exists(".env"))
+        {   
+            Console.WriteLine(".env의 토큰으로 인증을 진행합니다.");
+            Env.Load();
+            token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
             client.Credentials = new Credentials(token);
         }
 

--- a/reposcore-cs.csproj
+++ b/reposcore-cs.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cocona" Version="2.2.0" />
+    <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Octokit" Version="14.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/181

### ISSUE_TITLE
 [REFACTOR] GitHub 토큰 관리 자동화

###  기준 커밋 (Specify version - commit id)
1ad32cd77c05f6c92301c1df846e3771e360d3b6

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 
-t 옵션을 사용해 토큰을 입력 시,  .env파일을 생성 후 입력받은 토큰을 저장합니다. 
이후 -t 옵션을 사용하지 않더라도 저장된 토큰을 사용해 인증을 진행합니다.



### 🧪 테스트 방법 
`dotnet run -- oss2025hnu reposcore-cs -t 인증토큰` -> .env 파일에 토큰 저장(갱신)
`dotnet run -- oss2025hnu reposcore-cs` ->  .env 파일이 존재할 경우,  저장된 토큰으로 인증을 진행


