### PR TITLE
--format 옵션값이 부적절한 경우 반드시 오류 상태로 종료

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -122,6 +122,7 @@ static List<string> getValidFormat(string format)
             Console.Write($"{unValidFormat} ");
         }
         Console.Write("\n");
+        Environment.Exit(1);
     }
 
     // 유효한 포맷이 존재 X


### PR DESCRIPTION
### ISSUE_ID
#201

### ISSUE_TITLE
--format 옵션값이 부적절한 경우 반드시 오류 상태로 종료

###  기준 커밋 (Specify version - commit id)
fabf376358e835abf3812c1936cab2ce7178d940

### 변경사항
- [x] 유효하지 않은 --format 옵션 입력 시 프로그램이 실행을 계속하지 않고 `exit(1)`로 비정상 종료되도록 수정
- [x] `getValidFormat()` 함수 내부에서 잘못된 포맷이 하나라도 감지되면 경고 메시지를 출력하고 종료
- [x] 올바른 CLI 프로그램의 표준 동작 방식(정확한 인자/옵션 사용 시에만 실행)을 따르도록 수정\

![image](https://github.com/user-attachments/assets/698fa6df-cf67-4360-aca9-08641a1f6ced)