### PR TITLE
API호출 rate limit의 안내 개선

### DIFF
--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -91,7 +91,20 @@ public class RepoDataCollector // 1단계: 저장소에서 필요한 데이터�
         }
         catch (RateLimitExceededException)
         {
-            Console.WriteLine("❗ API 호출 한도(Rate Limit)를 초과했습니다. 잠시 후 다시 시도해주세요.");
+            try
+            {
+                var rateLimits = _client.Miscellaneous.GetRateLimits().Result;
+                var coreRateLimit = rateLimits.Rate;
+                var resetTime = coreRateLimit.Reset; // UTC DateTime
+                var secondsUntilReset = (int)(resetTime - DateTimeOffset.UtcNow).TotalSeconds;
+
+                Console.WriteLine($"❗ API 호출 한도(Rate Limit)를 초과했습니다. {secondsUntilReset}초 후 재시도 가능합니다 (약 {resetTime.LocalDateTime} 기준).");
+            }
+            catch (Exception innerEx)
+            {
+                Console.WriteLine($"❗ API 호출 한도 초과, 재시도 시간을 가져오는 데 실패했습니다: {innerEx.Message}");
+            }
+
             Environment.Exit(1);
         }
         catch (AuthorizationException)


### PR DESCRIPTION
### ISSUE_ID
(https://github.com/oss2025hnu/reposcore-cs/issues/146)

### ISSUE_TITLE
GitHub API RateLimit 발생 시 재시도 또는 사용자 안내 메시지 추가 

###  기준 커밋 (Specify version - commit id)
522487e3123e61100c542c3f3eb3828d41539e6c

### 변경사항
RateLimitExceededException 블록에서 Reset 시간을 가져와서 현재시간과 비교 후 안내 메시지 출력

### 💬 참고 사항 (선택 사항)
이슈에서 언급한 사용자 입력에 따라 재시도 기능은 구현 하지 않음
