### PR TITLE
파일 생성 시 유효하지 않은 파일 이름에 대한 오류 메시지 개선

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -109,12 +109,23 @@ static List<string> checkFormat(string[] format)
 
     var validFormats = new List<string> { };
     var unValidFormats = new List<string> { };
+    char[] invalidChars = Path.GetInvalidFileNameChars();
 
     foreach (var fm in format)
     {
         var f = fm.Trim().ToLowerInvariant(); // 대소문자 구분 없이 유효성 검사
-        if (FormatList.Contains(f)) validFormats.Add(f);
-        else unValidFormats.Add(f);
+        if (f.IndexOfAny(invalidChars) >= 0)
+        {
+            Console.WriteLine($"포맷 '{f}'에는 파일명으로 사용할 수 없는 문자가 포함되어 있습니다.");
+            Console.WriteLine("포맷 이름에서 다음 문자를 사용하지 마세요: " +
+                string.Join(" ", invalidChars.Select(c => $"'{c}'")));
+            Environment.Exit(1);
+        }
+
+        if (FormatList.Contains(f))
+            validFormats.Add(f);
+        else
+            unValidFormats.Add(f);
     }
 
     // 유효하지 않은 포맷이 존재


### PR DESCRIPTION
### ISSUE_ID
#142

### ISSUE_TITLE
파일 생성 시 유효하지 않은 파일 이름에 대한 오류 메시지 개선

###  기준 커밋 (Specify version - commit id)
9b89668bc0023e7c114daa0c932fbfba1cdf6f34

### 변경사항
- [✔] 파일 이름으로 사용할 수 없는 문자가 포함된 포맷을 사전에 탐지  
- [✔] 유효하지 않은 포맷에 대한 사용자 친화적인 오류 메시지 출력  
- [✔] 검사 순서를 "파일명 유효성 → 포맷 유효성"으로 명확하게 구조화  
- 
<img width="781" alt="스크린샷 2025-05-26 12 59 36" src="https://github.com/user-attachments/assets/2d307ad9-0a1a-4cca-9593-1e8468d8ca0f" />