### PR TITLE
GetRateLimits() API 코드 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.{cs,vb}]
+
+# IDE0130: 네임스페이스가 폴더 구조와 일치하지 않습니다.
+dotnet_diagnostic.IDE0130.severity = none

--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,8 @@
 using Cocona;
-using System;
-using System.Collections.Generic;
-using Octokit;
 using DotNetEnv;
+using reposcore_cs.Services.GitHub;
 
-CoconaApp.Run((
+CoconaApp.Run(static (
     [Argument] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
     [Option('o', Description = "출력 디렉토리 경로를 지정합니다.")] string? output,
@@ -82,7 +80,6 @@ CoconaApp.Run((
             var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
 
             var dataCollector = new RepoDataCollector(token!); // ✅ null-forgiving 연산자 적용
-            dataCollector.Collect(owner, repo, outputDir, formats);
 
             // ===== 파일 생성 기능 구현 후 제거 =====
             Console.WriteLine("\n===생성되는 포맷===");

--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -1,148 +1,146 @@
-using Octokit;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+global using Octokit;
+global using System;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
 
 // 현재 이름만 바꾼 거고 싹 다 재설계해야 함
-public class RepoDataCollector // 1단계: 저장소에서 필요한 데이터를 가져오는 역할
-{
-    private readonly GitHubClient _client;
-
-    public RepoDataCollector(string token)
+namespace reposcore_cs.Services.GitHub;
+    public class RepoDataCollector(string token) // 1단계: 저장소에서 필요한 데이터를 가져오는 역할
     {
-        _client = CreateClient("reposcore-cs", token);
-    }
+        private readonly GitHubClient _client = CreateClient("reposcore-cs", token);
 
-    private GitHubClient CreateClient(string productName, string token)
-    {
-        var client = new GitHubClient(new ProductHeaderValue(productName));
-
-        if (!string.IsNullOrEmpty(token))
+        private static GitHubClient CreateClient(string productName, string token)
         {
-            client.Credentials = new Credentials(token);
+            var client = new GitHubClient(new ProductHeaderValue(productName));
+
+            if (!string.IsNullOrEmpty(token))
+            {
+                client.Credentials = new Credentials(token);
+            }
+
+            return client;
         }
 
-        return client;
-    }
-
-    private void HandleError(Exception ex)
-    {
-        Console.WriteLine($"❗ 알 수 없는 오류가 발생했습니다: {ex.Message}");
-        Environment.Exit(1);
-    }
-
-    public Dictionary<string, int> Collect(string owner, string repo, string outputDir, List<string> formats)
-    {
-        try
+        private static void HandleError(Exception ex)
         {
-            Console.WriteLine("📥 Pull Requests 로딩 중...");
-            var prs = _client.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest
-            {
-                State = ItemStateFilter.Closed
-            }).Result;
-
-            Console.WriteLine("📥 Issues 로딩 중...");
-            var issues = _client.Issue.GetAllForRepository(owner, repo, new RepositoryIssueRequest
-            {
-                State = ItemStateFilter.All
-            }).Result;
-
-            Console.WriteLine("🔍 라벨 통계 분석 중...");
-            var targetLabels = new[] { "bug", "documentation", "enhancement" };
-            var labelCounts = targetLabels.ToDictionary(label => label, _ => 0);
-
-            foreach (var pr in prs.Where(p => p.Merged == true))
-            {
-                var labels = pr.Labels.Select(l => l.Name.ToLower()).ToList();
-                foreach (var label in targetLabels)
-                {
-                    if (labels.Contains(label))
-                        labelCounts[label]++;
-                }
-            }
-
-            foreach (var issue in issues)
-            {
-                if (issue.PullRequest != null) continue;
-                var labels = issue.Labels.Select(l => l.Name.ToLower()).ToList();
-                foreach (var label in targetLabels)
-                {
-                    if (labels.Contains(label))
-                        labelCounts[label]++;
-                }
-            }
-
-            Console.WriteLine("\n📊 GitHub Label 통계 결과");
-
-            Console.WriteLine("\n✅ Pull Requests (Merged)");
-            foreach (var label in targetLabels)
-            {
-                Console.WriteLine($"- {char.ToUpper(label[0]) + label.Substring(1)} PRs: {labelCounts[label]}");
-            }
-
-            Console.WriteLine("\n✅ Issues");
-            foreach (var label in targetLabels)
-            {
-                Console.WriteLine($"- {char.ToUpper(label[0]) + label.Substring(1)} Issues: {labelCounts[label]}");
-            }
-
-            return labelCounts;
+            Console.WriteLine($"❗ 알 수 없는 오류가 발생했습니다: {ex.Message}");
+            Environment.Exit(1);
         }
-        catch (RateLimitExceededException)
+
+        [Obsolete]
+        public Dictionary<string, int> Collect(string owner, string repo, string outputDir, List<string> formats)
         {
             try
             {
-                var rateLimits = _client.Miscellaneous.GetRateLimits().Result;
-                var coreRateLimit = rateLimits.Rate;
-                var resetTime = coreRateLimit.Reset; // UTC DateTime
-                var secondsUntilReset = (int)(resetTime - DateTimeOffset.UtcNow).TotalSeconds;
+                Console.WriteLine("📥 Pull Requests 로딩 중...");
+                var prs = _client.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest
+                {
+                    State = ItemStateFilter.Closed
+                }).Result;
 
-                Console.WriteLine($"❗ API 호출 한도(Rate Limit)를 초과했습니다. {secondsUntilReset}초 후 재시도 가능합니다 (약 {resetTime.LocalDateTime} 기준).");
+                Console.WriteLine("📥 Issues 로딩 중...");
+                var issues = _client.Issue.GetAllForRepository(owner, repo, new RepositoryIssueRequest
+                {
+                    State = ItemStateFilter.All
+                }).Result;
+
+                Console.WriteLine("🔍 라벨 통계 분석 중...");
+                var targetLabels = new[] { "bug", "documentation", "enhancement" };
+                var labelCounts = targetLabels.ToDictionary(label => label, _ => 0);
+
+                foreach (var pr in prs.Where(p => p.Merged == true))
+                {
+                    var labels = pr.Labels.Select(l => l.Name.ToLower()).ToList();
+                    foreach (var label in targetLabels)
+                    {
+                        if (labels.Contains(label))
+                            labelCounts[label]++;
+                    }
+                }
+
+                foreach (var issue in issues)
+                {
+                    if (issue.PullRequest != null) continue;
+                    var labels = issue.Labels.Select(l => l.Name.ToLower()).ToList();
+                    foreach (var label in targetLabels)
+                    {
+                        if (labels.Contains(label))
+                            labelCounts[label]++;
+                    }
+                }
+
+                Console.WriteLine("\n📊 GitHub Label 통계 결과");
+
+                Console.WriteLine("\n✅ Pull Requests (Merged)");
+                foreach (var label in targetLabels)
+                {
+                    Console.WriteLine($"- {char.ToUpper(label[0]) + label[1..]} PRs: {labelCounts[label]}");
+                }
+
+                Console.WriteLine("\n✅ Issues");
+                foreach (var label in targetLabels)
+                {
+                    Console.WriteLine($"- {char.ToUpper(label[0]) + label[1..]} Issues: {labelCounts[label]}");
+                }
+
+                return labelCounts;
             }
-            catch (Exception innerEx)
+            catch (RateLimitExceededException)
             {
-                Console.WriteLine($"❗ API 호출 한도 초과, 재시도 시간을 가져오는 데 실패했습니다: {innerEx.Message}");
+                try
+                {
+                    var client = new GitHubClient(new ProductHeaderValue("reposcore-cs"));
+                    var rateLimits = _client.Miscellaneous.GetRateLimits().Result;
+                    var coreRateLimit = rateLimits.Rate;
+                    var resetTime = coreRateLimit.Reset; // UTC DateTime
+                    var secondsUntilReset = (int)(resetTime - DateTimeOffset.UtcNow).TotalSeconds;
+
+                    Console.WriteLine($"❗ API 호출 한도(Rate Limit)를 초과했습니다. {secondsUntilReset}초 후 재시도 가능합니다 (약 {resetTime.LocalDateTime} 기준).");
+                }
+                catch (Exception innerEx)
+                {
+                    Console.WriteLine($"❗ API 호출 한도 초과, 재시도 시간을 가져오는 데 실패했습니다: {innerEx.Message}");
+                }
+
+                Environment.Exit(1);
             }
-
-            Environment.Exit(1);
-        }
-        catch (AuthorizationException)
-        {
-            Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
-            Environment.Exit(1);
-        }
-        catch (NotFoundException)
-        {
-            Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
-            Environment.Exit(1);
-        }
-        catch (Exception ex)
-        {
-            HandleError(ex);
-        }
-        return new Dictionary<string, int>();
-    }
-
-    // 결과물 만들어내는 이거는 3단계에서 할 일이니까 이것도 다른 곳으로 옮겨야 함
-    private void GenerateOutputFiles(string outputDir, List<string> formats)
-    {
-        try
-        {
-            Directory.CreateDirectory(outputDir);
-
-            foreach (var format in formats)
+            catch (AuthorizationException)
             {
-                string fileName = $"result.{format.ToLower()}";
-                string filePath = Path.Combine(outputDir, fileName);
+                Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
+                Environment.Exit(1);
+            }
+            catch (NotFoundException)
+            {
+                Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
+                Environment.Exit(1);
+            }
+            catch (Exception ex)
+            {
+                HandleError(ex);
+            }
+            return [];
+        }
 
-                File.WriteAllText(filePath, string.Empty);
-                Console.WriteLine($"📁 생성된 파일: {filePath}");
+        // 결과물 만들어내는 이거는 3단계에서 할 일이니까 이것도 다른 곳으로 옮겨야 함
+        private void GenerateOutputFiles(string outputDir, List<string> formats)
+        {
+            try
+            {
+                Directory.CreateDirectory(outputDir);
+
+                foreach (var format in formats)
+                {
+                    string fileName = $"result.{format.ToLower()}";
+                    string filePath = Path.Combine(outputDir, fileName);
+
+                    File.WriteAllText(filePath, string.Empty);
+                    Console.WriteLine($"📁 생성된 파일: {filePath}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"❗ 출력 파일 생성 중 오류: {ex.Message}");
             }
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"❗ 출력 파일 생성 중 오류: {ex.Message}");
-        }
     }
-}


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/212

### ISSUE_TITLE
[BUG] 더 이상 권장되지 않는 GetRateLimits() API 교체 


###  기준 커밋 (Specify version - commit id)
892ce2da01b358296d63de6a9ceda0bf9642d779

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 : RepoDataCollector.cs 내 IDE0130 경고 무시 추가
- [ ] 변경 사항 2 : 클라이언트 업데이트로 관련 변수나 객체 구성도 함께 리팩토링


### 🧪 테스트 방법 (선택 사항)
$ dotnet build
  Determining projects to restore...
  All projects are up-to-date for restore.
  reposcore-cs -> /workspaces/reposcore-cs/bin/Debug/net8.0/reposcore-cs.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:09.30

### 💬 참고 사항 (선택 사항)
변경 사항 2번에 추가 설명 -> 경고 무시 없이 dotnet build를 하면 에러가 뜨는 관계로 무시말곤 답이 보이지 않아서 임시로 추가해놓은 상태입니다.
그리고 무조건 var rateLimits = _client.Miscellaneous.GetRateLimits().Result; 에서 Miscellaneous를 RateLimitClient로 바꾸지는 않고 
Octokit 라이브러리에서 GitHub API 요청을 보낼 때 사용하는 기본 클라이언트 객체를 만드는 코드를 추가하여 해결하였습니다.
