### PR TITLE
통합 분석을 위한 저장소 인자를 다수로 받을 수 있게 변경

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -66,6 +66,23 @@ CoconaApp.Run((
             Console.WriteLine($"[INFO] Open Issues: {repository.OpenIssuesCount}");
             Console.WriteLine($"[INFO] Language: {repository.Language}");
             Console.WriteLine($"[INFO] URL: {repository.HtmlUrl}");
+            
+            var prRequest = new PullRequestRequest
+            {
+                State = ItemStateFilter.Closed
+            };
+            var pullRequests = client.PullRequest.GetAllForRepository(owner, repo, prRequest).GetAwaiter().GetResult();
+            var mergedCount = pullRequests.Count(pr => pr.MergedAt != null);
+
+            var issueRequest = new RepositoryIssueRequest
+            {
+                State = ItemStateFilter.All
+            };
+            var issues = client.Issue.GetAllForRepository(owner, repo, issueRequest).GetAwaiter().GetResult();
+            var issueCount = issues.Count;
+
+            Console.WriteLine($"[INFO] Merged Pull Requests: {mergedCount}");
+            Console.WriteLine($"[INFO] Total Issues: {issueCount}");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
### ISSUE_ID
#222 

### ISSUE_TITLE
통합 분석을 위한 저장소 인자를 다수로 받을 수 있게 변경

###  기준 커밋 (Specify version - commit id)
28724ba0015a4e069f882ddeff62d31f05be1cc2

### 변경사항
• 저장소 인자를 "owner/repo" 형식으로 다수 입력받을 수 있도록 변경
• 각 저장소에 대해 GitHub API를 호출하여 병합된 PR 수 및 전체 이슈 수 출력
• 기존 단일 저장소 분석 로직은 그대로 유지하며, 반복 처리로 확장 가능하도록 설계
<img width="846" alt="스크린샷 2025-05-27 12 25 43" src="https://github.com/user-attachments/assets/666178e1-a971-41a2-90dd-b69770ce6ed6" />