### PR TITLE
[TYPO] devcontainer.json 쉼표 누락

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       "extensions": [
         "ms-dotnettools.csharp",
         "ms-dotnettools.csdevkit",
-        "mechatroner.rainbow-csv"
+        "mechatroner.rainbow-csv",
         "ritwickdey.LiveServer"
       ]
     }


### PR DESCRIPTION
### ISSUE_ID
없음

### ISSUE_TITLE
devcontainer.json 쉼표 누락으로 인하여 실행 오류
코드스페이스를 새로 추가하여 열었을 때 오류가 남.

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/4f59ab1816bef15a988a897e8bd216308f1e3cf9

### 변경사항
```
"ms-dotnettools.csharp",
"ms-dotnettools.csdevkit",
"mechatroner.rainbow-csv"
"ritwickdey.LiveServer"
```
에서
```
"ms-dotnettools.csharp",
"ms-dotnettools.csdevkit",
"mechatroner.rainbow-csv",
"ritwickdey.LiveServer"
```
로 수정


### 💬 참고 사항 (선택 사항)
버그로 올려야할 이슈인지, 타이포인지 생각하다 쉼표 하나만 추가하면 되는 문제이기에 TYPO로 올렸습니다.
버그로 판단 하신다면, 삭제 후 이슈로 다시 올리겠습니다.