### PR TITLE
저장소 분석 시 분석로그 코드 일부 삭제

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -5,8 +5,6 @@ using Octokit;
 using DotNetEnv;
 
 
-CoconaApp.Run(static(
-    [Argument] string[] repos,
 CoconaApp.Run((
     [Argument(Description = "분석할 저장소. \"owner/repo\" 형식으로 공백을 구분자로 하여 여러 개 입력")] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
@@ -62,12 +60,7 @@ CoconaApp.Run((
             var repository = client.Repository.Get(owner, repo).GetAwaiter().GetResult();
 
             Console.WriteLine($"[INFO] Repository Name: {repository.Name}");
-            Console.WriteLine($"[INFO] Full Name: {repository.FullName}");
             Console.WriteLine($"[INFO] Description: {repository.Description}");
-            Console.WriteLine($"[INFO] Stars: {repository.StargazersCount}");
-            Console.WriteLine($"[INFO] Forks: {repository.ForksCount}");
-            Console.WriteLine($"[INFO] Open Issues: {repository.OpenIssuesCount}");
-            Console.WriteLine($"[INFO] Language: {repository.Language}");
             Console.WriteLine($"[INFO] URL: {repository.HtmlUrl}");
         }
         catch (Exception e)


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/221

### ISSUE_TITLE
저장소 분석 시 불필요한 분석 로그를 제거

###  기준 커밋 (Specify version - commit id)
8fdaf4e156913a12c75a104533490130f99ac449

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1 : 저장소 분석 시 분석로그 코드 일부 삭제

### 💬 참고 사항 (선택 사항)
이제 분석할 시에는 분석한 저장소 이름과 설명 그리고 해당 링크로 갈 수 있는 URL만 출력됩니다.
