### PR TITLE
RepoDataCollector 클래스 재설계

### DIFF
--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -1,145 +1,164 @@
-global using Octokit;
-global using System;
-global using System.Collections.Generic;
-global using System.IO;
-global using System.Linq;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DotNetEnv;
 
-// 현재 이름만 바꾼 거고 싹 다 재설계해야 함
-    public class RepoDataCollector(string token) // 1단계: 저장소에서 필요한 데이터를 가져오는 역할
+public class RepoDataCollector
+{
+    private static GitHubClient? _client;
+    private readonly string _owner;
+    private readonly string _repo;
+
+    // 생성자에는 저장소 하나의 정보를 넘김
+    public RepoDataCollector(string owner, string repo)
     {
-        private readonly GitHubClient _client = CreateClient("reposcore-cs", token);
+        _owner = owner;
+        _repo = repo;
+    }
 
-        private static GitHubClient CreateClient(string productName, string token)
+    // GitHubClient 초기화 메소드
+    public static void CreateClient(string? token = null)
+    {
+        _client = new GitHubClient(new ProductHeaderValue("reposcore-cs"));
+
+        // 인증키 추가 (토큰이 있을경우)
+        if (!string.IsNullOrEmpty(token))
         {
-            var client = new GitHubClient(new ProductHeaderValue(productName));
+            File.WriteAllText(".env", $"GITHUB_TOKEN={token}\n");
+            Console.WriteLine(".env의 토큰을 갱신합니다.");
+            _client.Credentials = new Credentials(token);
+        }
+        else if (File.Exists(".env"))
+        {
+            Console.WriteLine(".env의 토큰으로 인증을 진행합니다.");
+            Env.Load();
+            token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+            _client.Credentials = new Credentials(token);
+        }
+    }
 
-            if (!string.IsNullOrEmpty(token))
-            {
-                client.Credentials = new Credentials(token);
-            }
+    // 수집용 mutable 클래스 (Collect 메소드에서만 사용)
+    private class MutableUserActivity
+    {
+        public int PR_fb = 0;
+        public int PR_doc = 0;
+        public int PR_typo = 0;
+        public int IS_fb = 0;
+        public int IS_doc = 0;
+    }
 
-            return client;
+    // Collect 메소드
+    public Dictionary<string, UserActivity> Collect(bool returnDummyData = false)
+    {
+        if (returnDummyData)
+        {
+            return DummyData.repo1Activities;
         }
 
-        private static void HandleError(Exception ex)
+        try
+        {
+            // Issues수집 (RP포함)
+            var allIssuesAndPRs = _client!.Issue.GetAllForRepository(_owner, _repo, new RepositoryIssueRequest
+            {
+                State = ItemStateFilter.All
+            }).Result;
+
+            // 수집용 mutable 객체. 모든 데이터 수집 후 레코드로 변환하여 반환
+            var mutableActivities = new Dictionary<string, MutableUserActivity>();
+
+            // allIssuesAndPRs의 데이터를 유저,라벨별로 분류
+            foreach (var item in allIssuesAndPRs)
+            {
+                if (item.User?.Login == null) continue;
+
+                var username = item.User.Login;
+
+                // 처음 기록하는 사용자 초기화
+                if (!mutableActivities.ContainsKey(username))
+                {
+                    mutableActivities[username] = new MutableUserActivity();
+                }
+
+                var labelName = item.Labels.Any() ? item.Labels[0].Name : null; // 라벨 구분을 위한 labelName
+
+                var activity = mutableActivities[username];
+
+                if (item.PullRequest != null) // PR일 경우
+                {
+                    if (item.PullRequest.Merged) // 병합된 PR만 집계
+                    {
+                        if (labelName == "bug" || labelName == "enhancement")
+                            activity.PR_fb++;
+                        else if (labelName == "documentation")
+                            activity.PR_doc++;
+                        else if (labelName == "typo")
+                            activity.PR_typo++;
+                    }
+                }
+                else
+                {
+                    if (item.State.Value.ToString() == "Open" ||
+                        item.StateReason.ToString() == "completed") // 열려있거나 정상적으로 닫힌 이슈들만 집계
+                    {
+                        if (labelName == "bug" || labelName == "enhancement")
+                            activity.IS_fb++;
+                        else if (labelName == "documentation")
+                            activity.IS_doc++;
+
+                    }
+                }
+            }
+
+            // 레코드로 변환
+            var userActivities = new Dictionary<string, UserActivity>();
+            foreach (var (key, value) in mutableActivities)
+            {
+                userActivities[key] = new UserActivity(
+                    PR_fb: value.PR_fb,
+                    PR_doc: value.PR_doc,
+                    PR_typo: value.PR_typo,
+                    IS_fb: value.IS_fb,
+                    IS_doc: value.IS_doc
+                );
+            }
+
+            return userActivities;
+        }
+        catch (RateLimitExceededException)
+        {
+            try
+            {
+                var rateLimits = _client!.RateLimit.GetRateLimits().Result;
+                var coreRateLimit = rateLimits.Rate;
+                var resetTime = coreRateLimit.Reset; // UTC DateTime
+                var secondsUntilReset = (int)(resetTime - DateTimeOffset.UtcNow).TotalSeconds;
+
+                Console.WriteLine($"❗ API 호출 한도(Rate Limit)를 초과했습니다. {secondsUntilReset}초 후 재시도 가능합니다 (약 {resetTime.LocalDateTime} 기준).");
+            }
+            catch (Exception innerEx)
+            {
+                Console.WriteLine($"❗ API 호출 한도 초과, 재시도 시간을 가져오는 데 실패했습니다: {innerEx.Message}");
+            }
+
+            Environment.Exit(1);
+        }
+        catch (AuthorizationException)
+        {
+            Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
+            Environment.Exit(1);
+        }
+        catch (NotFoundException)
+        {
+            Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
+            Environment.Exit(1);
+        }
+        catch (Exception ex)
         {
             Console.WriteLine($"❗ 알 수 없는 오류가 발생했습니다: {ex.Message}");
             Environment.Exit(1);
         }
-
-        [Obsolete]
-        public Dictionary<string, int> Collect(string owner, string repo, string outputDir, List<string> formats)
-        {
-            try
-            {
-                Console.WriteLine("📥 Pull Requests 로딩 중...");
-                var prs = _client.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest
-                {
-                    State = ItemStateFilter.Closed
-                }).Result;
-
-                Console.WriteLine("📥 Issues 로딩 중...");
-                var issues = _client.Issue.GetAllForRepository(owner, repo, new RepositoryIssueRequest
-                {
-                    State = ItemStateFilter.All
-                }).Result;
-
-                Console.WriteLine("🔍 라벨 통계 분석 중...");
-                var targetLabels = new[] { "bug", "documentation", "enhancement" };
-                var labelCounts = targetLabels.ToDictionary(label => label, _ => 0);
-
-                foreach (var pr in prs.Where(p => p.Merged == true))
-                {
-                    var labels = pr.Labels.Select(l => l.Name.ToLower()).ToList();
-                    foreach (var label in targetLabels)
-                    {
-                        if (labels.Contains(label))
-                            labelCounts[label]++;
-                    }
-                }
-
-                foreach (var issue in issues)
-                {
-                    if (issue.PullRequest != null) continue;
-                    var labels = issue.Labels.Select(l => l.Name.ToLower()).ToList();
-                    foreach (var label in targetLabels)
-                    {
-                        if (labels.Contains(label))
-                            labelCounts[label]++;
-                    }
-                }
-
-                Console.WriteLine("\n📊 GitHub Label 통계 결과");
-
-                Console.WriteLine("\n✅ Pull Requests (Merged)");
-                foreach (var label in targetLabels)
-                {
-                    Console.WriteLine($"- {char.ToUpper(label[0]) + label[1..]} PRs: {labelCounts[label]}");
-                }
-
-                Console.WriteLine("\n✅ Issues");
-                foreach (var label in targetLabels)
-                {
-                    Console.WriteLine($"- {char.ToUpper(label[0]) + label[1..]} Issues: {labelCounts[label]}");
-                }
-
-                return labelCounts;
-            }
-            catch (RateLimitExceededException)
-            {
-                try
-                {
-                    var client = new GitHubClient(new ProductHeaderValue("reposcore-cs"));
-                    var rateLimits = _client.Miscellaneous.GetRateLimits().Result;
-                    var coreRateLimit = rateLimits.Rate;
-                    var resetTime = coreRateLimit.Reset; // UTC DateTime
-                    var secondsUntilReset = (int)(resetTime - DateTimeOffset.UtcNow).TotalSeconds;
-
-                    Console.WriteLine($"❗ API 호출 한도(Rate Limit)를 초과했습니다. {secondsUntilReset}초 후 재시도 가능합니다 (약 {resetTime.LocalDateTime} 기준).");
-                }
-                catch (Exception innerEx)
-                {
-                    Console.WriteLine($"❗ API 호출 한도 초과, 재시도 시간을 가져오는 데 실패했습니다: {innerEx.Message}");
-                }
-
-                Environment.Exit(1);
-            }
-            catch (AuthorizationException)
-            {
-                Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
-                Environment.Exit(1);
-            }
-            catch (NotFoundException)
-            {
-                Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
-                Environment.Exit(1);
-            }
-            catch (Exception ex)
-            {
-                HandleError(ex);
-            }
-            return [];
-        }
-
-        // 결과물 만들어내는 이거는 3단계에서 할 일이니까 이것도 다른 곳으로 옮겨야 함
-        private void GenerateOutputFiles(string outputDir, List<string> formats)
-        {
-            try
-            {
-                Directory.CreateDirectory(outputDir);
-
-                foreach (var format in formats)
-                {
-                    string fileName = $"result.{format.ToLower()}";
-                    string filePath = Path.Combine(outputDir, fileName);
-
-                    File.WriteAllText(filePath, string.Empty);
-                    Console.WriteLine($"📁 생성된 파일: {filePath}");
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"❗ 출력 파일 생성 중 오류: {ex.Message}");
-            }
-        }
+        return null!;
     }
+}


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/231

### ISSUE_TITLE
RepoDataCollector 클래스 재설계

###  기준 커밋 (Specify version - commit id)
24689eda5573d419c3dfdeab02d113259bc9c589

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
하나의 저장소 정보 (소유자,저장 이름)을 받아 분석하는 RepoDataCollector 클래스 재설계
- [ ] 변경 사항 1
`GitHubClient` 를 static 멤버로 선언하였으며 이를 초기화하는 `CreateClient` 메소드 구현
- [ ] 변경 사항 2
PR/이슈를 분석하여 사용자ID를 키로 하고 활동 건수 정보를 담은 레코드인 UserActivity 값으로 이루어진 딕셔너리를 리턴 하는 
`Collect` 메소드 구현
 이때 PR/이슈의 개수의 집계에는 mutable 클래스인 `MutableUserActivity`을 사용후, 레코드로 변환하여 반환
- [ ] 변경 사항 3
변경된 RepoDataCollector클래스에 맞게 `Program.cs`가 일부 변경
클라이언트의 초기화는 다음과 같이 한번만 이루어지며 저장소의 개수만큼 RepoDataCollector 클래스의 인스턴스가 생성
```
// _client 초기화 
RepoDataCollector.CreateClient(token);
foreach (var repoPath in repos)
{
.
.
.

  // collector 생성
  var collector = new RepoDataCollector(owner, repo);
  
  // 데이터 수집
  var userActivities = collector.Collect();
}

```
- [ ] 변경 사항 4
수집된 결과를 확인하기 위한 txt 파일 생성. 이는 테스트를 위한 것으로, 추후 삭제되어야함.
- [ ] 변경 사항 5
기존 존재하던 라벨카운터는 기존의 RepoDataCollector 클래스를 사용하고 있었는데, RepoDataCollector 클래스가 변경된 관계로 
`Program.cs`에 해당 코드를 구현
- [ ] 변경 사항 6
Collect 메소드가  더미 데이터를 바로 리턴하는 기능 구현, 파라미터 `returnDummyData`으로 사용가능. 기본값은 false