### PR TITLE
repoPath의 파싱 로직 분리

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -26,25 +26,11 @@ CoconaApp.Run((
     RepoDataCollector.CreateClient(token);
 
     foreach (var repoPath in repos)
-    {
-        if (!repoPath.Contains('/'))
-        {
-            Console.WriteLine($"! 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다.");
-            continue;
-        }
-
-        var parts = repoPath.Split('/');
-        if (parts.Length != 2)
-        {
-            Console.WriteLine($"! 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다.");
-            continue;
-        }
-
-        string owner = parts[0];
-        string repo = parts[1];
+    {   
+        // repoPath 파싱 및 형식 검사 
+        var (owner,repo) = ParseRepoPath(repoPath);
 
         Console.WriteLine($"\n🔍 처리 중: {owner}/{repo}");
-
         try
         {
             // collector 생성
@@ -175,4 +161,22 @@ static List<string> checkFormat(string[] format)
     }
 
     return validFormats;
+}
+
+static (string, string) ParseRepoPath(string repoPath)
+{
+    if (!repoPath.Contains('/'))
+    {
+        Console.WriteLine($"! 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다.");
+        Environment.Exit(1);
+    }
+
+    var parts = repoPath.Split('/');
+    if (parts.Length != 2)
+    {
+        Console.WriteLine($"! 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다.");
+        Environment.Exit(1);
+    }
+
+    return (parts[0], parts[1]);
 }


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/244

### ISSUE_TITLE
저장소 인자(repoPath) 파싱 로직을 함수로 분리

###  기준 커밋 (Specify version - commit id)
9439f0b79343e5890c51bcd46a9bc4ede4bd2f3b

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1
repoPath의 형식을 검사하고 파싱하여 (ower, repo) 형식의 튜플을 반환하는 `ParseRepoPath` 함수 작성 
- [ ] 변경 사항 2
기존의 파싱 코드를 해당 함수로 대체

