### PR TITLE
csv 생성기능 구현

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -85,14 +85,26 @@ CoconaApp.Run((
 
             var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
 
-            // ===== 파일 생성 기능 구현 후 제거 =====
-            Console.WriteLine("\n===생성되는 포맷===");
-            foreach (var fm in formats)
+            // 점수 계산 기능이 구현되지 않았으므로 현재 생성되는 파일은 모두 DummyData의 repo1Scores으로 만들어짐
+            // 추후 계산 기능이 구현 후 반환되는 값을 DummyData.repo1Scores대신 전달해야합니다
+            var generator = new FileGenerator(DummyData.repo1Scores, repo, outputDir);
+
+            if (formats.Contains("csv"))
             {
-                Console.WriteLine($"-{fm}");
+                generator.GenerateCsv();
             }
-            Console.WriteLine("\n파일 생성 기능이 아직 구현되지 않았습니다.");
-            // ===== 파일 생성 기능 구현 후 제거 =====
+            if (formats.Contains("text"))
+            {
+                Console.WriteLine("텍스트 파일 생성이 아직 구현되지 않았습니다.");
+            }
+            if (formats.Contains("chart"))
+            {
+                Console.WriteLine("차트 생성이 아직 구현되지 않았습니다.");
+            }
+            if (formats.Contains("html"))
+            {
+                Console.WriteLine("html 파일 생성이 아직 구현되지 않았습니다.");
+            }
         }
         catch (Exception ex)
         {

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -11,11 +11,12 @@ public record UserActivity(
 
 // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
 public record UserScore(
-    // int ????, // 점수의 이름은 나중에 정하기,
-    // int ????, // 점수의 이름은 나중에 정하기,
-    // int ????, // 점수의 이름은 나중에 정하기,
-    // int ????, // 점수의 이름은 나중에 정하기,
-    // int ????, // 점수의 이름은 나중에 정하기,
+    int PR_fb,
+    int PR_doc,
+    int PR_typo,
+    int IS_fb,
+    int IS_doc,
+    int total
 );
 
 // 1번 단계를 책임지는 Repscore/RepoDataCollector.cs의 클래스의 객체 하나가
@@ -44,6 +45,21 @@ public static class DummyData
         { "user10", new UserActivity(21, 9, 13, 4, 11) },
         { "user11", new UserActivity(2, 18, 7, 15, 10) },
         { "user12", new UserActivity(16, 3, 12, 8, 14) },
+    };
+
+    public static Dictionary<string, UserScore> repo1Scores = new()
+    {
+        {"user01", new UserScore(21, 8, 0, 4, 3, 36)},
+        {"user02", new UserScore(12, 6, 5, 2, 1, 26)},
+        {"user03", new UserScore(3, 2, 3, 6, 2, 16)},
+        {"user04", new UserScore(18, 10, 4, 8, 1, 41)},
+        {"user05", new UserScore(9, 4, 2, 2, 5, 22)},
+        {"user06", new UserScore(6, 12, 1, 6, 3, 28)},
+        {"user07", new UserScore(15, 14, 5, 4, 2, 40)},
+        {"user08", new UserScore(27, 16, 3, 10, 4, 60)},
+        {"user09", new UserScore(30, 6, 0, 12, 1, 49)},
+        {"user10", new UserScore(24, 18, 2, 14, 2, 60)},
+        {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
     };
 }
 

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+public class FileGenerator
+{
+    private readonly Dictionary<string, UserScore> _scores;
+    private readonly string _repoName;
+    private readonly string _folderPath;
+
+    public FileGenerator(Dictionary<string, UserScore> repoScores, string repoName, string folderPath)
+    {
+        _scores = repoScores;
+        _repoName = repoName;
+        _folderPath = folderPath;
+
+        // 폴더생성
+        Directory.CreateDirectory(folderPath);
+    }
+
+    public void GenerateCsv()
+    {      
+        // 경로 설정
+        string filePath = Path.Combine(_folderPath, $"{_repoName}.csv");
+        using StreamWriter writer = new StreamWriter(filePath);
+
+        // CSV 헤더
+        writer.WriteLine("UserId,f/b_PR,doc_PR,typo,f/b_issue,doc_issue,total");
+
+        // 내용 작성
+        foreach (var (id, socres) in _scores)
+        {
+            string line = $"{id},{socres.PR_fb},{socres.PR_doc},{socres.PR_typo},{socres.IS_fb},{socres.IS_doc},{socres.total}";
+            writer.WriteLine(line);
+        }
+
+        Console.WriteLine($"{filePath} 생성됨");
+    }
+}


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/245

### ISSUE_TITLE
--format 옵션에 따라 출력 결과 파일 생성 기능 구현 (text, csv, html)

###  기준 커밋 (Specify version - commit id)
074bfe88be2c2761bd2bfedea13bfb20e34be211

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ ] 변경 사항 1
파일 생성 기능과 관련된 `FileGenerator` 클래스 구현
맴버 변수는 하나의 저장소의 점수인 `_scores`, 파일 이름을 위한 `_repoName`, 폴더 이름을 위한 `_folderPath`
생성자 함수가 호출될때 결과 저장 폴더를 생성합니다.
`_scores`를 바탕으로 csv를 생성하는 `GenerateCsv` 메소드 구현
- [ ] 변경 사항 2
`CommonData.cs`의 `DummyData`에 점수 더미데이터인 `repo1Scores`를 추가
`Dictionary<string, UserScore>` 타입을 따르며 이는 추후 구현될 점수 계산 함수가 반환할 타입입니다.
- [ ] 변경 사항 3
점수 계산 기능이 구현되지 않았기 때문에 더미데이터인 `repo1Scores`를 사용해 csv를 생성, 계산 기능이 구현 후 `repo1Scores` 대신 점수 계산 함수가 반환하는 데이터를 전달
`Program.cs`의 파일 생성 분기를 작성, 추후 다른 파일 생성 기능 구현 후 사용 예정.

### 🧪 테스트 방법 (선택 사항)
<!-- 변경 사항이 정상 동작하는지 어떻게 확인했는지 작성해주세요 -->
`dotnet run -- oss2025hnu/reposcore-cs oss2025hnu/reposcore-py oss2025hnu/reposcore-js` 입력시
`output` 폴더에 `reposcore-cs.csv`, `reposcore-py.csv`, `reposcore-js.csv` 파일 생성
파일 내용은 현재 더미데이터를 사용하기 때문에 모두 동일함

