### PR TITLE
UserActivity의 속성을 가변으로 정의후 사용

### DIFF
--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -1,13 +1,25 @@
 using System.Collections.Generic;
 
-// 깃헙에서 우리가 필요한 정보를 가져와서 담아놓는 레코드 (각 내역별 활동 횟수)
-public record UserActivity(
-    int PR_fb,
-    int PR_doc,
-    int PR_typo,
-    int IS_fb,
-    int IS_doc
-);
+// 가변 속성으로 바꾼 UserActivity 레코드
+public record UserActivity
+{
+    public int PR_fb { get; set; }
+    public int PR_doc { get; set; }
+    public int PR_typo { get; set; }
+    public int IS_fb { get; set; }
+    public int IS_doc { get; set; }
+
+    public UserActivity() {}
+
+    public UserActivity(int prFb, int prDoc, int prTypo, int isFb, int isDoc)
+    {
+        PR_fb = prFb;
+        PR_doc = prDoc;
+        PR_typo = prTypo;
+        IS_fb = isFb;
+        IS_doc = isDoc;
+    }
+}
 
 // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
 public record UserScore(
@@ -35,6 +47,7 @@ public static class DummyData
         { "user08", new UserActivity(0, 0, 0, 10, 0) },
         { "user09", new UserActivity(0, 0, 0, 0, 10) },
     };
+
     public static Dictionary<string, UserActivity> repo2Activities = new() {
         { "user03", new UserActivity(26, 27, 28, 29, 30) },
         { "user04", new UserActivity(31, 32, 33, 34, 35) },
@@ -62,6 +75,7 @@ public static class DummyData
         {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
     };
 }
+
 
 /*
 1단계 RepoDataCollector


### PR DESCRIPTION
ISSUE_ID

https://github.com/oss2025hnu/reposcore-cs/issues/249

ISSUE_TITLE
UserActivity의 속성을 가변으로 정의 후 사용

기준 커밋 (Specify version - commit id)
5810e98939664964aba5a4c2fdcb422d455997a2

변경사항


- `UserActivity`는 이제 `get; set;`을 통해 수집 중에도 값을 누적할 수 있는 구조입니다.

- 기존 `Dictionary<string, UserActivity>` 사용 코드에는 아무런 수정 없이 그대로 호환됩니다.

- 별도 `MutableUserActivity` 없이 바로 누적 가능하므로 코드가 단순해지고 유지보수도 쉬워집니다.