### PR TITLE
Split과 Contains(/)를 동시에 사용하는 중복 검사 문제

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -177,12 +177,6 @@ static List<string> checkFormat(string[] format)
 
 static (string, string) ParseRepoPath(string repoPath)
 {
-    if (!repoPath.Contains('/'))
-    {
-        Console.WriteLine($"! 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다.");
-        Environment.Exit(1);
-    }
-
     var parts = repoPath.Split('/');
     if (parts.Length != 2)
     {


### PR DESCRIPTION
### ISSUE_ID
#201

### ISSUE_TITLE
repo.Contains('/')와 Split('/') 중복 검사 제거

###  기준 커밋 (Specify version - commit id)
22dab416b868b3350a858849f9b964365766cee0

### 변경사항
- [x] ParseRepoPath() 함수 내 repo.Contains('/') 중복 검사 제거
- [x] Split('/')의 길이로만 저장소 형식 유효성 검사 수행
- [x] 코드 간결화 및 중복 로직 제거
