### PR TITLE
--include-user 옵션 추가 및 사용자별 결과 필터링 기능 구현

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,8 @@ CoconaApp.Run((
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
     [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (default : \"result\")")] string? output,
     [Option('f', Description = "출력 형식 지정 (\"text\", \"csv\", \"chart\", \"html\", \"all\", default : \"all\")")] string[]? format,
-    [Option('t', Description = "GitHub 액세스 토큰 입력")] string? token
+    [Option('t', Description = "GitHub 액세스 토큰 입력")] string? token,
+    [Option("include-user", Description = "결과에 포함할 사용자 ID 목록")] string[]? includeUsers
 ) =>
 {
     // 더미 데이타가 실제로 불러와 지는지 기본적으로 확인하기 위한 코드
@@ -50,10 +51,16 @@ CoconaApp.Run((
             using (var writer = new StreamWriter(filePath))
             {
                 writer.WriteLine($"=== {repo} Activities ===");
+                HashSet<string>? userSet = null;
+                if (includeUsers != null && includeUsers.Length > 0)
+                    userSet = new HashSet<string>(includeUsers, StringComparer.OrdinalIgnoreCase);
                 foreach (var kvp in userActivities)
                 {
                     string userId = kvp.Key;
                     UserActivity activity = kvp.Value;
+
+                    if (userSet != null && !userSet.Contains(userId))
+                        continue;
 
                     writer.WriteLine($"User ID: {userId}");
                     writer.WriteLine($"  PR_fb: {activity.PR_fb}");


### PR DESCRIPTION
### ISSUE_ID
#258 

### ISSUE_TITLE
특정 사용자만 포함하는 필터 옵션 추가

###  기준 커밋 (Specify version - commit id)
947c0f8

### 변경사항
- --include-user 옵션을 추가하여, 특정 사용자 ID만 결과에 포함할 수 있도록 기능을 구현했습니다.
- Program.cs에서 사용자 데이터를 순회하는 시점에 includeUsers 필터를 적용하여, 지정한 사용자만 결과 파일 및 통계에 반영됩니다.
- 옵션 미지정 시 기존과 동일하게 전체 사용자가 출력됩니다.


### 🧪 테스트 방법 (선택 사항)
- --include-user 옵션 없이 실행 시 전체 사용자 결과 출력
- --include-user user01 user02 등으로 실행 시 지정한 사용자만 결과에 포함되는지 확인