### PR TITLE
점수 총합 기준 내림차순 정렬 기능 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -29,7 +29,7 @@ public class FileGenerator
         writer.WriteLine("UserId,f/b_PR,doc_PR,typo,f/b_issue,doc_issue,total");
 
         // 내용 작성
-        foreach (var (id, socres) in _scores)
+        foreach (var (id, socres) in _scores.OrderByDescending(x => x.Value.total))
         {
             string line = $"{id},{socres.PR_fb},{socres.PR_doc},{socres.PR_typo},{socres.IS_fb},{socres.IS_doc},{socres.total}";
             writer.WriteLine(line);

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -51,7 +51,7 @@ public class FileGenerator
         var table = new ConsoleTable(headers);
 
         // 내용 작성
-        foreach (var (id, scores) in _scores)
+        foreach (var (id, scores) in _scores.OrderByDescending(x => x.Value.total))
         {
             table.AddRow(
                 id.PadRight(colWidths[0]), // 글자는 왼쪽 정렬                   


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/256

### ISSUE_TITLE
점수 총합 기준 내림차순 정렬 기능 추가

###  기준 커밋 (Specify version - commit id)
b6ae52c9d2e7c3956babd12a57a66b7fcdd6e4e7

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
-FileGenerator.cs의 `GenerateCsv`에서 출력 순서를 `UserScore.total` 기준 내림차순으로 정렬
-FileGenerator.cs의 `GenerateTable`에서도 동일하게 정렬 적용



