### PR TITLE
PR/이슈 구분 통계 출력 옵션 추가

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -10,9 +10,17 @@ CoconaApp.Run((
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
     [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (default : \"result\")")] string? output,
     [Option('f', Description = "출력 형식 지정 (\"text\", \"csv\", \"chart\", \"html\", \"all\", default : \"all\")")] string[]? format,
-    [Option('t', Description = "GitHub 액세스 토큰 입력")] string? token
+    [Option('t', Description = "GitHub 액세스 토큰 입력")] string? token,
+    [Option("only-pr", Description = "PR 활동만 분석합니다.")] bool onlyPR,
+    [Option("only-issue", Description = "이슈 활동만 분석합니다.")] bool onlyIssue
 ) =>
 {
+    //  옵션 충돌 방지: --only-pr 와 --only-issue는 동시에 사용 불가 
+    if (onlyPR && onlyIssue)
+    {
+        Console.WriteLine("❌ --only-pr 와 --only-issue 옵션은 동시에 사용할 수 없습니다.");
+        Environment.Exit(1);
+    }
     // 더미 데이타가 실제로 불러와 지는지 기본적으로 확인하기 위한 코드
     var repo1Activities = DummyData.repo1Activities;
     Console.WriteLine("repo1Activities:" + repo1Activities.Count);
@@ -38,6 +46,26 @@ CoconaApp.Run((
 
             // 데이터 수집
             var userActivities = collector.Collect();
+
+            if (onlyPR)
+            {
+                // 이슈 활동 제거
+                foreach (var activity in userActivities.Values)
+                {
+                    activity.IS_fb = 0;
+                    activity.IS_doc = 0;
+                }
+            }
+            else if (onlyIssue)
+            {
+                // PR 활동 제거
+                foreach (var activity in userActivities.Values)
+                {
+                    activity.PR_fb = 0;
+                    activity.PR_doc = 0;
+                    activity.PR_typo = 0;
+                }
+            }
 
             // 테스트 출력, 라벨 카운트 기능 유지
             Dictionary<string, int> labelCounts = new Dictionary<string, int>

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -1,13 +1,23 @@
 using System.Collections.Generic;
 
 // 깃헙에서 우리가 필요한 정보를 가져와서 담아놓는 레코드 (각 내역별 활동 횟수)
-public record UserActivity(
-    int PR_fb,
-    int PR_doc,
-    int PR_typo,
-    int IS_fb,
-    int IS_doc
-);
+public class UserActivity
+{
+    public int PR_fb { get; set; }
+    public int PR_doc { get; set; }
+    public int PR_typo { get; set; }
+    public int IS_fb { get; set; }
+    public int IS_doc { get; set; }
+
+    public UserActivity(int pr_fb, int pr_doc, int pr_typo, int is_fb, int is_doc)
+    {
+        PR_fb = pr_fb;
+        PR_doc = pr_doc;
+        PR_typo = pr_typo;
+        IS_fb = is_fb;
+        IS_doc = is_doc;
+    }
+}
 
 // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
 public record UserScore(

--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -135,14 +135,15 @@ public class RepoDataCollector
 
             // 레코드로 변환
             var userActivities = new Dictionary<string, UserActivity>();
-            foreach (var (key, value) in mutableActivities)
+            foreach (var (key, activity) in mutableActivities)
             {
+                // PR_fb, PR_doc, PR_typo, IS_fb, IS_doc 순서
                 userActivities[key] = new UserActivity(
-                    PR_fb: value.PR_fb,
-                    PR_doc: value.PR_doc,
-                    PR_typo: value.PR_typo,
-                    IS_fb: value.IS_fb,
-                    IS_doc: value.IS_doc
+                    activity.PR_fb,
+                    activity.PR_doc,
+                    activity.PR_typo,
+                    activity.IS_fb,
+                    activity.IS_doc
                 );
             }
 


### PR DESCRIPTION
### ISSUE_ID
#269

### ISSUE_TITLE
PR/이슈 구분 통계 출력 옵션 추가

###  기준 커밋 (Specify version - commit id)
743dd6ad5c75cca159eb9f13da332d76f53e6f87

### 변경사항
- [x] `--only-pr` 옵션 추가: PR 활동만 분석되도록 설정 가능
- [x] `--only-issue` 옵션 추가: 이슈 활동만 분석되도록 설정 가능
- [x] 두 옵션은 상호 배타적으로 동작하며, 동시에 입력 시 에러 메시지 출력 후 종료
- [x] `UserActivity`를 `record` → `class`로 변경하고, 필드 수정 가능하도록 `get; set;` 사용

![스크린샷 2025-06-01 234931](https://github.com/user-attachments/assets/c389521e-c525-4d0a-99c9-dd77c76f5c5b)

### 🧪 테스트 방법 (선택 사항)
```bash
dotnet run -- oss2025hnu/reposcore-cs --only-pr
dotnet run -- oss2025hnu/reposcore-cs --only-issue
```