### PR TITLE
옵션 입력 누락 시 기본값 안내 메시지 출력

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -19,6 +19,24 @@ CoconaApp.Run((
     var repo2Activities = DummyData.repo2Activities;
     Console.WriteLine("repo2Activities:" + repo2Activities.Count);
 
+   // ───────────────────────────────────────────────────────
+   // 1) output 옵션 누락 시 기본값 안내
+   // ───────────────────────────────────────────────────────
+   if (string.IsNullOrWhiteSpace(output))
+   {
+       // 실제 디폴트 값은 코드에서 "output"으로 설정되어 있음
+       Console.WriteLine("출력 디렉토리가 지정되지 않아 기본값 'output'이 사용됩니다.");
+   }
+
+   // ───────────────────────────────────────────────────────
+   // 2) format 옵션 누락 시 기본값 안내
+   // ───────────────────────────────────────────────────────
+   if (format == null || format.Length == 0)
+   {
+       // 여기서 기본값 배열은 {"text", "csv", "chart", "html"}으로 설정됨
+       Console.WriteLine("출력 형식이 지정되지 않아 기본값 'text,csv,chart,html'이 사용됩니다.");
+   }
+    
     // 저장소별 라벨 통계 요약 정보를 저장할 리스트
     var summaries = new List<(string RepoName, Dictionary<string, int> LabelCounts)>();
 
@@ -77,13 +95,26 @@ CoconaApp.Run((
             continue;
         }
 
-        try
+              try
         {
-            var formats = format == null ?
-                new List<string> { "text", "csv", "chart", "html" }
-                : checkFormat(format);
+            // ───────────────────────────────────────────────────────
+            // 3) 실제 format 기본값/유효성 검사 적용
+            // ───────────────────────────────────────────────────────
+            List<string> formats;
+            if (format == null || format.Length == 0)
+            {
+                formats = new List<string> { "text", "csv", "chart", "html" };
+            }
+            else
+            {
+                formats = checkFormat(format);
+            }
 
-            var outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
+            // ───────────────────────────────────────────────────────
+            // 4) 실제 outputDir 기본값 적용
+            // ───────────────────────────────────────────────────────
+            string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
+
 
             // 점수 계산 기능이 구현되지 않았으므로 현재 생성되는 파일은 모두 DummyData의 repo1Scores으로 만들어짐
             // 추후 계산 기능이 구현 후 반환되는 값을 DummyData.repo1Scores대신 전달해야합니다

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ CoconaApp.Run((
    if (string.IsNullOrWhiteSpace(output))
    {
        // 실제 디폴트 값은 코드에서 "output"으로 설정되어 있음
-       Console.WriteLine("출력 디렉토리가 지정되지 않아 기본값 'output'이 사용됩니다.");
+       Console.WriteLine("출력 디렉토리가 지정되지 않아 기본 경로 'output/'이 사용됩니다.");
    }
 
    // ───────────────────────────────────────────────────────
@@ -34,7 +34,7 @@ CoconaApp.Run((
    if (format == null || format.Length == 0)
    {
        // 여기서 기본값 배열은 {"text", "csv", "chart", "html"}으로 설정됨
-       Console.WriteLine("출력 형식이 지정되지 않아 기본값 'text,csv,chart,html'이 사용됩니다.");
+       Console.WriteLine("출력 형식이 지정되지 않아 기본값 'all'이 사용됩니다.");
    }
     
     // 저장소별 라벨 통계 요약 정보를 저장할 리스트


### PR DESCRIPTION
### ISSUE_ID
](https://github.com/oss2025hnu/reposcore-cs/issues/268)

### ISSUE_TITLE
옵션 입력 누락 시 기본값 안내 메시지 출력

###  기준 커밋 (Specify version - commit id)
3aed50c93e478f4e97da1e4f220dbc4407e9af21

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [ CoconaApp.Run 내부에 output 옵션이 누락됐을 때 메시지를 출력] 
- [ CoconaApp.Run 내부에 format 옵션이 누락됐을 때 메시지를 출력]


### 🧪 테스트 방법 (선택 사항)
옵션없이 실행시
=>출력 디렉토리가 지정되지 않아 기본 경로 'output/'이 사용됩니다.
=>출력 형식이 지정되지 않아 기본값 'all'이 사용됩니다.

### 💬 참고 사항 (선택 사항)
향후 format이나 output의 기본값이 변경되면 안내 메시지도 함께 수정해야 함
