### PR TITLE
GitHub Actions에 dotnet build 추가

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -1,0 +1,25 @@
+name: Build .NET Project
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release


### PR DESCRIPTION
### ISSUE_ID
#155


### ISSUE_TITLE

GitHub Actions에 dotnet build 추가

###  기준 커밋 (Specify version - commit id)
61259be9aa7ea8745b3fa7f3128b5e9826417690

### 변경사항
GitHub Actions 설정 파일을 추가하여 main 브랜치에 push 또는 PR 시 dotnet build 자동 실행되도록 구성 