### PR TITLE
RepoDataCollector.cs에서 UserActivity 속성 초기화 방식으로 수정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,69 +1,14 @@
 ﻿using Cocona;
 
-// ───────────────────────────────────────────────────────
-// ① 캐시 시뮬레이션 상수 (현재는 항상 Disabled)
-// ───────────────────────────────────────────────────────
-const bool CACHE_ENABLED = false;
-
 CoconaApp.Run((
     [Argument(Description = "분석할 저장소. \"owner/repo\" 형식으로 공백을 구분자로 하여 여러 개 입력")] string[] repos,
     [Option('v', Description = "자세한 로그 출력을 활성화합니다.")] bool verbose,
     [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (default : \"result\")", ValueName = "Output directory")] string? output,
     [Option('f', Description = "출력 형식 지정 (\"text\", \"csv\", \"chart\", \"html\", \"all\", default : \"all\")", ValueName = "Output format")] string[]? format,
     [Option('t', Description = "GitHub 액세스 토큰 입력", ValueName = "Github token")] string? token,
-    [Option("include-user", Description = "결과에 포함할 사용자 ID 목록", ValueName = "Include user's id")] string[]? includeUsers,
-    [Option("dry-run", Description = "실제 작업 없이 시뮬레이션 로그만 출력")] bool dryRun
+    [Option("include-user", Description = "결과에 포함할 사용자 ID 목록", ValueName = "Include user's id")] string[]? includeUsers
 ) =>
 {
-    // ─────────────────────────────────────────────────────────────
-    // ①-0) dry-run일 경우: 실제 로직 실행 전 “시뮬레이션 로그” 출력 후 종료
-    // ─────────────────────────────────────────────────────────────
-    if (dryRun)
-    {
-        Console.WriteLine("===== Dry-Run 시뮬레이션 =====");
-        Console.WriteLine("분석 대상 저장소 목록:");
-        foreach (var repoPath in repos)
-        {
-            Console.WriteLine($"  - {repoPath}");
-        }
-        Console.WriteLine();
-
-        Console.WriteLine($"캐시 사용 여부: {(CACHE_ENABLED ? "Enabled" : "Disabled")}");
-        Console.WriteLine();
-
-        Console.WriteLine("API 호출 예정 여부: Yes (GitHub API를 사용하여 데이터를 가져올 예정)");
-        Console.WriteLine();
-
-        // format과 outputDir을 시뮬레이션용으로 계산
-        List<string> _simFormats;
-        if (format == null || format.Length == 0)
-        {
-            _simFormats = new List<string> { "text", "csv", "chart", "html" };
-        }
-        else
-        {
-            _simFormats = checkFormat(format);
-        }
-        string _simOutputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
-
-        Console.WriteLine($"출력 디렉토리 예상 위치: {_simOutputDir}/<repoName>.[csv|txt]");
-        Console.WriteLine("생성될 파일 형식:");
-        foreach (var fmt in _simFormats)
-        {
-            if (fmt == "csv")
-                Console.WriteLine($"  · {_simOutputDir}/<repoName>.csv");
-            if (fmt == "text")
-                Console.WriteLine($"  · {_simOutputDir}/<repoName>.txt");
-            if (fmt == "chart")
-                Console.WriteLine($"  · [차트 기능 미구현으로 표시]");
-            if (fmt == "html")
-                Console.WriteLine($"  · [HTML 기능 미구현으로 표시]");
-        }
-
-        Console.WriteLine("\n===== 시뮬레이션 종료 =====");
-        return;
-    }
-
     // ───────────────────────────────────────────────────────
     // 1) output 옵션 누락 시 기본값 안내
     // ───────────────────────────────────────────────────────

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -36,32 +36,6 @@ public record UserActivity
 // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 public static class DummyData
 {
-    public static Dictionary<string, UserActivity> repo1Activities = new() {
-    { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-    { "user01", new UserActivity { PR_fb = 0, PR_doc = 1, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-    { "user02", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 1, IS_fb = 0, IS_doc = 0 } },
-    { "user03", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 1, IS_doc = 0 } },
-    { "user04", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 1 } },
-    { "user05", new UserActivity { PR_fb = 10, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-    { "user06", new UserActivity { PR_fb = 0, PR_doc = 10, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-    { "user07", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 10, IS_fb = 0, IS_doc = 0 } },
-    { "user08", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 10, IS_doc = 0 } },
-    { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
-};
-
-    public static Dictionary<string, UserActivity> repo2Activities = new() {
-    { "user03", new UserActivity { PR_fb = 26, PR_doc = 27, PR_typo = 28, IS_fb = 29, IS_doc = 30 } },
-    { "user04", new UserActivity { PR_fb = 31, PR_doc = 32, PR_typo = 33, IS_fb = 34, IS_doc = 35 } },
-    { "user05", new UserActivity { PR_fb = 36, PR_doc = 37, PR_typo = 38, IS_fb = 39, IS_doc = 40 } },
-    { "user06", new UserActivity { PR_fb = 41, PR_doc = 42, PR_typo = 43, IS_fb = 44, IS_doc = 45 } },
-    { "user08", new UserActivity { PR_fb = 12, PR_doc = 5, PR_typo = 8, IS_fb = 3, IS_doc = 17 } },
-    { "user09", new UserActivity { PR_fb = 7, PR_doc = 14, PR_typo = 2, IS_fb = 19, IS_doc = 6 } },
-    { "user10", new UserActivity { PR_fb = 21, PR_doc = 9, PR_typo = 13, IS_fb = 4, IS_doc = 11 } },
-    { "user11", new UserActivity { PR_fb = 2, PR_doc = 18, PR_typo = 7, IS_fb = 15, IS_doc = 10 } },
-    { "user12", new UserActivity { PR_fb = 16, PR_doc = 3, PR_typo = 12, IS_fb = 8, IS_doc = 14 } },
-};
-
-
     public static Dictionary<string, UserActivity> repo1Activities = new()
     {
         { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
@@ -74,9 +48,22 @@ public static class DummyData
         { "user07", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 10, IS_fb = 0, IS_doc = 0 } },
         { "user08", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 10, IS_doc = 0 } },
         { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
+    };
 
+    public static Dictionary<string, UserActivity> repo2Activities = new()
+    {
+        { "user03", new UserActivity { PR_fb = 26, PR_doc = 27, PR_typo = 28, IS_fb = 29, IS_doc = 30 } },
+        { "user04", new UserActivity { PR_fb = 31, PR_doc = 32, PR_typo = 33, IS_fb = 34, IS_doc = 35 } },
+        { "user05", new UserActivity { PR_fb = 36, PR_doc = 37, PR_typo = 38, IS_fb = 39, IS_doc = 40 } },
+        { "user06", new UserActivity { PR_fb = 41, PR_doc = 42, PR_typo = 43, IS_fb = 44, IS_doc = 45 } },
+        { "user08", new UserActivity { PR_fb = 12, PR_doc = 5, PR_typo = 8, IS_fb = 3, IS_doc = 17 } },
+        { "user09", new UserActivity { PR_fb = 7, PR_doc = 14, PR_typo = 2, IS_fb = 19, IS_doc = 6 } },
+        { "user10", new UserActivity { PR_fb = 21, PR_doc = 9, PR_typo = 13, IS_fb = 4, IS_doc = 11 } },
+        { "user11", new UserActivity { PR_fb = 2, PR_doc = 18, PR_typo = 7, IS_fb = 15, IS_doc = 10 } },
+        { "user12", new UserActivity { PR_fb = 16, PR_doc = 3, PR_typo = 12, IS_fb = 8, IS_doc = 14 } },
     };
 }
+
 
 
 /*

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -51,21 +51,20 @@ public static Dictionary<string, UserActivity> repo2Activities = new() {
 };
 
 
-    public static Dictionary<string, UserScore> repo1Scores = new()
+    public static Dictionary<string, UserActivity> repo1Activities = new()
     {
-        {"user01", new UserScore(21, 8, 0, 4, 3, 36)},
-        {"user02", new UserScore(12, 6, 5, 2, 1, 26)},
-        {"user03", new UserScore(3, 2, 3, 6, 2, 16)},
-        {"user04", new UserScore(18, 10, 4, 8, 1, 41)},
-        {"user05", new UserScore(9, 4, 2, 2, 5, 22)},
-        {"user06", new UserScore(6, 12, 1, 6, 3, 28)},
-        {"user07", new UserScore(15, 14, 5, 4, 2, 40)},
-        {"user08", new UserScore(27, 16, 3, 10, 4, 60)},
-        {"user09", new UserScore(30, 6, 0, 12, 1, 49)},
-        {"user10", new UserScore(24, 18, 2, 14, 2, 60)},
-        {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
+        { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+        { "user01", new UserActivity { PR_fb = 0, PR_doc = 1, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+        { "user02", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 1, IS_fb = 0, IS_doc = 0 } },
+        { "user03", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 1, IS_doc = 0 } },
+        { "user04", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 1 } },
+        { "user05", new UserActivity { PR_fb = 10, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+        { "user06", new UserActivity { PR_fb = 0, PR_doc = 10, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+        { "user07", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 10, IS_fb = 0, IS_doc = 0 } },
+        { "user08", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 10, IS_doc = 0 } },
+        { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
+
     };
-}
 
 
 /*

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -8,6 +8,15 @@ public record UserActivity
     public int PR_typo { get; set; }
     public int IS_fb { get; set; }
     public int IS_doc { get; set; }
+
+    public void Deconstruct(out int prFb, out int prDoc, out int prTypo, out int isFb, out int isDoc)
+    {
+        prFb = PR_fb;
+        prDoc = PR_doc;
+        prTypo = PR_typo;
+        isFb = IS_fb;
+        isDoc = IS_doc;
+    }
 }
 
     // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -10,6 +10,7 @@ public record UserActivity
     public int IS_doc { get; set; }
 }
 
+
     // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
     public record UserScore(
         int PR_fb,
@@ -24,30 +25,31 @@ public record UserActivity
 // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 public static class DummyData
 {
-    public static Dictionary<string, UserActivity> repo1Activities = new() {
-        { "user00", new UserActivity(1, 0, 0, 0, 0) },
-        { "user01", new UserActivity(0, 1, 0, 0, 0) },
-        { "user02", new UserActivity(0, 0, 1, 0, 0) },
-        { "user03", new UserActivity(0, 0, 0, 1, 0) },
-        { "user04", new UserActivity(0, 0, 0, 0, 1) },
-        { "user05", new UserActivity(10, 0, 0, 0, 0) },
-        { "user06", new UserActivity(0, 10, 0, 0, 0) },
-        { "user07", new UserActivity(0, 0, 10, 0, 0) },
-        { "user08", new UserActivity(0, 0, 0, 10, 0) },
-        { "user09", new UserActivity(0, 0, 0, 0, 10) },
-    };
+public static Dictionary<string, UserActivity> repo1Activities = new() {
+    { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+    { "user01", new UserActivity { PR_fb = 0, PR_doc = 1, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+    { "user02", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 1, IS_fb = 0, IS_doc = 0 } },
+    { "user03", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 1, IS_doc = 0 } },
+    { "user04", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 1 } },
+    { "user05", new UserActivity { PR_fb = 10, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+    { "user06", new UserActivity { PR_fb = 0, PR_doc = 10, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
+    { "user07", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 10, IS_fb = 0, IS_doc = 0 } },
+    { "user08", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 10, IS_doc = 0 } },
+    { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
+};
 
-    public static Dictionary<string, UserActivity> repo2Activities = new() {
-        { "user03", new UserActivity(26, 27, 28, 29, 30) },
-        { "user04", new UserActivity(31, 32, 33, 34, 35) },
-        { "user05", new UserActivity(36, 37, 38, 39, 40) },
-        { "user06", new UserActivity(41, 42, 43, 44, 45) },
-        { "user08", new UserActivity(12, 5, 8, 3, 17) },
-        { "user09", new UserActivity(7, 14, 2, 19, 6) },
-        { "user10", new UserActivity(21, 9, 13, 4, 11) },
-        { "user11", new UserActivity(2, 18, 7, 15, 10) },
-        { "user12", new UserActivity(16, 3, 12, 8, 14) },
-    };
+public static Dictionary<string, UserActivity> repo2Activities = new() {
+    { "user03", new UserActivity { PR_fb = 26, PR_doc = 27, PR_typo = 28, IS_fb = 29, IS_doc = 30 } },
+    { "user04", new UserActivity { PR_fb = 31, PR_doc = 32, PR_typo = 33, IS_fb = 34, IS_doc = 35 } },
+    { "user05", new UserActivity { PR_fb = 36, PR_doc = 37, PR_typo = 38, IS_fb = 39, IS_doc = 40 } },
+    { "user06", new UserActivity { PR_fb = 41, PR_doc = 42, PR_typo = 43, IS_fb = 44, IS_doc = 45 } },
+    { "user08", new UserActivity { PR_fb = 12, PR_doc = 5, PR_typo = 8, IS_fb = 3, IS_doc = 17 } },
+    { "user09", new UserActivity { PR_fb = 7, PR_doc = 14, PR_typo = 2, IS_fb = 19, IS_doc = 6 } },
+    { "user10", new UserActivity { PR_fb = 21, PR_doc = 9, PR_typo = 13, IS_fb = 4, IS_doc = 11 } },
+    { "user11", new UserActivity { PR_fb = 2, PR_doc = 18, PR_typo = 7, IS_fb = 15, IS_doc = 10 } },
+    { "user12", new UserActivity { PR_fb = 16, PR_doc = 3, PR_typo = 12, IS_fb = 8, IS_doc = 14 } },
+};
+
 
     public static Dictionary<string, UserScore> repo1Scores = new()
     {

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -36,7 +36,7 @@ public record UserActivity
 // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 public static class DummyData
 {
-public static Dictionary<string, UserActivity> repo1Activities = new() {
+    public static Dictionary<string, UserActivity> repo1Activities = new() {
     { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
     { "user01", new UserActivity { PR_fb = 0, PR_doc = 1, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
     { "user02", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 1, IS_fb = 0, IS_doc = 0 } },
@@ -49,7 +49,7 @@ public static Dictionary<string, UserActivity> repo1Activities = new() {
     { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
 };
 
-public static Dictionary<string, UserActivity> repo2Activities = new() {
+    public static Dictionary<string, UserActivity> repo2Activities = new() {
     { "user03", new UserActivity { PR_fb = 26, PR_doc = 27, PR_typo = 28, IS_fb = 29, IS_doc = 30 } },
     { "user04", new UserActivity { PR_fb = 31, PR_doc = 32, PR_typo = 33, IS_fb = 34, IS_doc = 35 } },
     { "user05", new UserActivity { PR_fb = 36, PR_doc = 37, PR_typo = 38, IS_fb = 39, IS_doc = 40 } },
@@ -76,6 +76,7 @@ public static Dictionary<string, UserActivity> repo2Activities = new() {
         { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
 
     };
+}
 
 
 /*

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-// 가변 속성으로 바꾼 UserActivity 레코드
+// 사용자 활동을 표현하는 레코드
 public record UserActivity
 {
     public int PR_fb { get; set; }
@@ -8,26 +8,17 @@ public record UserActivity
     public int PR_typo { get; set; }
     public int IS_fb { get; set; }
     public int IS_doc { get; set; }
-
-    public void Deconstruct(out int prFb, out int prDoc, out int prTypo, out int isFb, out int isDoc)
-    {
-        prFb = PR_fb;
-        prDoc = PR_doc;
-        prTypo = PR_typo;
-        isFb = IS_fb;
-        isDoc = IS_doc;
-    }
 }
 
-    // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
-    public record UserScore(
-        int PR_fb,
-        int PR_doc,
-        int PR_typo,
-        int IS_fb,
-        int IS_doc,
-        int total
-    );
+// 사용자 점수를 표현하는 레코드
+public record UserScore(
+    int PR_fb,
+    int PR_doc,
+    int PR_typo,
+    int IS_fb,
+    int IS_doc,
+    int total
+);
 
 public static class CommonData
 {
@@ -73,6 +64,7 @@ public static class CommonData
         { "user11", new UserScore(33, 20, 4, 16, 5, 78) }
     };
 }
+
 
 
 /*

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 
-// 사용자 활동을 표현하는 레코드
+// 가변 속성으로 바꾼 UserActivity 레코드
 public record UserActivity
 {
     public int PR_fb { get; set; }
@@ -10,7 +10,7 @@ public record UserActivity
     public int IS_doc { get; set; }
 }
 
-// 사용자 점수를 표현하는 레코드
+    // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
 public record UserScore(
     int PR_fb,
     int PR_doc,

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -1,23 +1,24 @@
 using System.Collections.Generic;
 
-// 깃헙에서 우리가 필요한 정보를 가져와서 담아놓는 레코드 (각 내역별 활동 횟수)
-public record UserActivity(
-    int PR_fb,
-    int PR_doc,
-    int PR_typo,
-    int IS_fb,
-    int IS_doc
-);
+// 가변 속성으로 바꾼 UserActivity 레코드
+public record UserActivity
+{
+    public int PR_fb { get; set; }
+    public int PR_doc { get; set; }
+    public int PR_typo { get; set; }
+    public int IS_fb { get; set; }
+    public int IS_doc { get; set; }
+}
 
-// UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
-public record UserScore(
-    int PR_fb,
-    int PR_doc,
-    int PR_typo,
-    int IS_fb,
-    int IS_doc,
-    int total
-);
+    // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
+    public record UserScore(
+        int PR_fb,
+        int PR_doc,
+        int PR_typo,
+        int IS_fb,
+        int IS_doc,
+        int total
+    );
 
 // 1번 단계를 책임지는 Repscore/RepoDataCollector.cs의 클래스의 객체 하나가
 // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
@@ -35,6 +36,7 @@ public static class DummyData
         { "user08", new UserActivity(0, 0, 0, 10, 0) },
         { "user09", new UserActivity(0, 0, 0, 0, 10) },
     };
+
     public static Dictionary<string, UserActivity> repo2Activities = new() {
         { "user03", new UserActivity(26, 27, 28, 29, 30) },
         { "user04", new UserActivity(31, 32, 33, 34, 35) },
@@ -62,6 +64,7 @@ public static class DummyData
         {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
     };
 }
+
 
 /*
 1단계 RepoDataCollector

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -8,19 +8,28 @@ public record UserActivity
     public int PR_typo { get; set; }
     public int IS_fb { get; set; }
     public int IS_doc { get; set; }
+
+    public void Deconstruct(out int prFb, out int prDoc, out int prTypo, out int isFb, out int isDoc)
+    {
+        prFb = PR_fb;
+        prDoc = PR_doc;
+        prTypo = PR_typo;
+        isFb = IS_fb;
+        isDoc = IS_doc;
+    }
 }
 
-// UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
-public record UserScore(
-    int PR_fb,
-    int PR_doc,
-    int PR_typo,
-    int IS_fb,
-    int IS_doc,
-    int total
-);
+    // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
+    public record UserScore(
+        int PR_fb,
+        int PR_doc,
+        int PR_typo,
+        int IS_fb,
+        int IS_doc,
+        int total
+    );
 
-public static class DummyData
+public static class CommonData
 {
     public static Dictionary<string, UserActivity> repo1Activities = new()
     {
@@ -35,9 +44,6 @@ public static class DummyData
         { "user08", new UserActivity { IS_fb = 10 } },
         { "user09", new UserActivity { IS_doc = 10 } },
     };
-
-    // 1번 단계를 책임지는 Repscore/RepoDataCollector.cs의 클래스의 객체 하나가
-    // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 
     public static Dictionary<string, UserActivity> repo2Activities = new()
     {
@@ -54,20 +60,19 @@ public static class DummyData
 
     public static Dictionary<string, UserScore> repo1Scores = new()
     {
-        {"user01", new UserScore(21, 8, 0, 4, 3, 36)},
-        {"user02", new UserScore(12, 6, 5, 2, 1, 26)},
-        {"user03", new UserScore(3, 2, 3, 6, 2, 16)},
-        {"user04", new UserScore(18, 10, 4, 8, 1, 41)},
-        {"user05", new UserScore(9, 4, 2, 2, 5, 22)},
-        {"user06", new UserScore(6, 12, 1, 6, 3, 28)},
-        {"user07", new UserScore(15, 14, 5, 4, 2, 40)},
-        {"user08", new UserScore(27, 16, 3, 10, 4, 60)},
-        {"user09", new UserScore(30, 6, 0, 12, 1, 49)},
-        {"user10", new UserScore(24, 18, 2, 14, 2, 60)},
-        {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
+        { "user01", new UserScore(21, 8, 0, 4, 3, 36) },
+        { "user02", new UserScore(12, 6, 5, 2, 1, 26) },
+        { "user03", new UserScore(3, 2, 3, 6, 2, 16) },
+        { "user04", new UserScore(18, 10, 4, 8, 1, 41) },
+        { "user05", new UserScore(9, 4, 2, 2, 5, 22) },
+        { "user06", new UserScore(6, 12, 1, 6, 3, 28) },
+        { "user07", new UserScore(15, 14, 5, 4, 2, 40) },
+        { "user08", new UserScore(27, 16, 3, 10, 4, 60) },
+        { "user09", new UserScore(30, 6, 0, 12, 1, 49) },
+        { "user10", new UserScore(24, 18, 2, 14, 2, 60) },
+        { "user11", new UserScore(33, 20, 4, 16, 5, 78) }
     };
 }
-
 
 
 /*

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -8,7 +8,18 @@ public record UserActivity
     public int PR_typo { get; set; }
     public int IS_fb { get; set; }
     public int IS_doc { get; set; }
+
+    // Deconstruct 메서드 추가
+    public void Deconstruct(out int prFb, out int prDoc, out int prTypo, out int isFb, out int isDoc)
+    {
+        prFb = PR_fb;
+        prDoc = PR_doc;
+        prTypo = PR_typo;
+        isFb = IS_fb;
+        isDoc = IS_doc;
+    }
 }
+
 
 
     // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드

--- a/Reposcore/CommonData.cs
+++ b/Reposcore/CommonData.cs
@@ -8,47 +8,36 @@ public record UserActivity
     public int PR_typo { get; set; }
     public int IS_fb { get; set; }
     public int IS_doc { get; set; }
-
-    // Deconstruct 메서드 추가
-    public void Deconstruct(out int prFb, out int prDoc, out int prTypo, out int isFb, out int isDoc)
-    {
-        prFb = PR_fb;
-        prDoc = PR_doc;
-        prTypo = PR_typo;
-        isFb = IS_fb;
-        isDoc = IS_doc;
-    }
 }
 
+// UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
+public record UserScore(
+    int PR_fb,
+    int PR_doc,
+    int PR_typo,
+    int IS_fb,
+    int IS_doc,
+    int total
+);
 
-
-    // UserActivity를 분석해서 사용자별 점수를 계산하는 레코드
-    public record UserScore(
-        int PR_fb,
-        int PR_doc,
-        int PR_typo,
-        int IS_fb,
-        int IS_doc,
-        int total
-    );
-
-// 1번 단계를 책임지는 Repscore/RepoDataCollector.cs의 클래스의 객체 하나가
-// 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 public static class DummyData
 {
     public static Dictionary<string, UserActivity> repo1Activities = new()
     {
-        { "user00", new UserActivity { PR_fb = 1, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-        { "user01", new UserActivity { PR_fb = 0, PR_doc = 1, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-        { "user02", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 1, IS_fb = 0, IS_doc = 0 } },
-        { "user03", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 1, IS_doc = 0 } },
-        { "user04", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 1 } },
-        { "user05", new UserActivity { PR_fb = 10, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-        { "user06", new UserActivity { PR_fb = 0, PR_doc = 10, PR_typo = 0, IS_fb = 0, IS_doc = 0 } },
-        { "user07", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 10, IS_fb = 0, IS_doc = 0 } },
-        { "user08", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 10, IS_doc = 0 } },
-        { "user09", new UserActivity { PR_fb = 0, PR_doc = 0, PR_typo = 0, IS_fb = 0, IS_doc = 10 } },
+        { "user00", new UserActivity { PR_fb = 1 } },
+        { "user01", new UserActivity { PR_doc = 1 } },
+        { "user02", new UserActivity { PR_typo = 1 } },
+        { "user03", new UserActivity { IS_fb = 1 } },
+        { "user04", new UserActivity { IS_doc = 1 } },
+        { "user05", new UserActivity { PR_fb = 10 } },
+        { "user06", new UserActivity { PR_doc = 10 } },
+        { "user07", new UserActivity { PR_typo = 10 } },
+        { "user08", new UserActivity { IS_fb = 10 } },
+        { "user09", new UserActivity { IS_doc = 10 } },
     };
+
+    // 1번 단계를 책임지는 Repscore/RepoDataCollector.cs의 클래스의 객체 하나가
+    // 모아오는 데이타가 바로 repo1Activities 같은 것이다.
 
     public static Dictionary<string, UserActivity> repo2Activities = new()
     {
@@ -61,6 +50,21 @@ public static class DummyData
         { "user10", new UserActivity { PR_fb = 21, PR_doc = 9, PR_typo = 13, IS_fb = 4, IS_doc = 11 } },
         { "user11", new UserActivity { PR_fb = 2, PR_doc = 18, PR_typo = 7, IS_fb = 15, IS_doc = 10 } },
         { "user12", new UserActivity { PR_fb = 16, PR_doc = 3, PR_typo = 12, IS_fb = 8, IS_doc = 14 } },
+    };
+
+    public static Dictionary<string, UserScore> repo1Scores = new()
+    {
+        {"user01", new UserScore(21, 8, 0, 4, 3, 36)},
+        {"user02", new UserScore(12, 6, 5, 2, 1, 26)},
+        {"user03", new UserScore(3, 2, 3, 6, 2, 16)},
+        {"user04", new UserScore(18, 10, 4, 8, 1, 41)},
+        {"user05", new UserScore(9, 4, 2, 2, 5, 22)},
+        {"user06", new UserScore(6, 12, 1, 6, 3, 28)},
+        {"user07", new UserScore(15, 14, 5, 4, 2, 40)},
+        {"user08", new UserScore(27, 16, 3, 10, 4, 60)},
+        {"user09", new UserScore(30, 6, 0, 12, 1, 49)},
+        {"user10", new UserScore(24, 18, 2, 14, 2, 60)},
+        {"user11", new UserScore(33, 20, 4, 16, 5, 78)}
     };
 }
 

--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -76,7 +76,7 @@ public class RepoDataCollector
     {
         if (returnDummyData)
         {
-            return DummyData.repo1Activities;
+            return CommonData.repo1Activities;
         }
 
         try
@@ -137,13 +137,14 @@ public class RepoDataCollector
             var userActivities = new Dictionary<string, UserActivity>();
             foreach (var (key, value) in mutableActivities)
             {
-                userActivities[key] = new UserActivity(
-                    PR_fb: value.PR_fb,
-                    PR_doc: value.PR_doc,
-                    PR_typo: value.PR_typo,
-                    IS_fb: value.IS_fb,
-                    IS_doc: value.IS_doc
-                );
+                userActivities[key] = new UserActivity
+                {
+                    PR_fb = value.PR_fb,
+                    PR_doc = value.PR_doc,
+                    PR_typo = value.PR_typo,
+                    IS_fb = value.IS_fb,
+                    IS_doc = value.IS_doc
+                };
             }
 
             return userActivities;


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/249

### ISSUE_TITLE
UserActivity record 생성자 관련 오류 수정 및 속성 초기화 방식 적용

###  기준 커밋 (Specify version - commit id)
efb73973e54cb0760deb94e59537c3fdcac7f22f
acad4d676adb92e54265f9aa532e502ec5bff225

### 변경사항
- CommonData.cs에서 UserActivity에 수동 생성자 제거됨에 따라,
  RepoDataCollector.cs에서도 생성자 호출 방식에서 속성 초기화 방식으로 변경
- 기존의 new UserActivity(...) → new UserActivity { ... } 방식으로 수정
- 오류 CS1739 ("parameter named 'PR_fb' 없음") 해결됨
- CommonData.cs와 RepoDataCollector.cs 모두 최신 구조 반영 완료