### PR TITLE
출력 파일을 한 폴더로 통합

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -118,7 +118,12 @@ CoconaApp.Run((
                 { "documentation", 0 },
                 { "typo", 0 }
             };
-            string filePath = $"{repo}.txt";
+            string filePath = Path.Combine("output", repo, $"{repo}2.txt");
+            string directoryPath = Path.GetDirectoryName(filePath) ?? throw new InvalidOperationException($"Invalid file path: {filePath}");
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
             using (var writer = new StreamWriter(filePath))
             {
                 writer.WriteLine($"=== {repo} Activities ===");

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -13,10 +13,8 @@ public class FileGenerator
     {
         _scores = repoScores;
         _repoName = repoName;
-        _folderPath = folderPath;
-
-        // 폴더생성
-        Directory.CreateDirectory(folderPath);
+        _folderPath = Path.Combine(folderPath, repoName);
+        Directory.CreateDirectory(_folderPath);
     }
 
     double sumOfPR
@@ -54,7 +52,7 @@ public class FileGenerator
     public void GenerateTable()
     {
         // 출력할 파일 경로
-        string filePath = Path.Combine(_folderPath, $"{_repoName}.txt");
+        string filePath = Path.Combine(_folderPath, $"{_repoName}1.txt");
 
         // 테이블 생성
         var headers = "UserId,f/b_PR,doc_PR,typo,f/b_issue,doc_issue,PR_rate,IS_rate,total".Split(',');


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/298

### ISSUE_TITLE
출력 파일이 의도치 않게 두 군데에 생성되는 문제

###  기준 커밋 (Specify version - commit id)
b879d07ed730eacf434ee376ec3d7263752aa059

### 변경사항
프로젝트 루트 디렉토리에 생성되는 txt 파일을 output/ 디렉토리 내부에 생성되도록 수정 
