### PR TITLE
dry-run 모드에서 --include-user 옵션이 적용

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,6 +20,12 @@ CoconaApp.Run((
     // ─────────────────────────────────────────────────────────────
     if (dryRun)
     {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            Console.WriteLine("[Dry-run] GitHub API를 호출하려면 --token 옵션이 필요합니다.");
+            return;
+        }
+        RepoDataCollector.CreateClient(token);
         Console.WriteLine("===== Dry-Run 시뮬레이션 =====");
         Console.WriteLine("분석 대상 저장소 목록:");
         foreach (var repoPath in repos)
@@ -58,6 +64,46 @@ CoconaApp.Run((
                 Console.WriteLine($"  · [차트 기능 미구현으로 표시]");
             if (fmt == "html")
                 Console.WriteLine($"  · [HTML 기능 미구현으로 표시]");
+        }
+
+        foreach (var repoPath in repos)
+        {
+            var parsed = TryParseRepoPath(repoPath);
+            if (parsed == null)
+            {
+                Console.WriteLine($"⚠️ 저장소 경로 무시됨 (형식 오류): {repoPath}");
+                continue;
+            }
+
+            var (owner, repo) = parsed.Value;
+            var collector = new RepoDataCollector(owner, repo);
+
+            Console.WriteLine($"\n[Dry-run] {owner}/{repo} 저장소 참여자 목록 조회 중...");
+
+            Dictionary<string, UserActivity> userActivities;
+            try
+            {
+                userActivities = collector.Collect(); // ✅ 실제 참여자 목록 가져오기
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Dry-run] 참여자 정보를 가져오는 데 실패했습니다: {ex.Message}");
+                continue;
+            }
+
+            var participantIds = userActivities.Keys.ToList();
+            Console.WriteLine($"[Dry-run] 총 참여자 {participantIds.Count}명: {string.Join(", ", participantIds)}");
+
+            if (includeUsers != null && includeUsers.Length > 0)
+            {
+                Console.WriteLine($"[Dry-run] --include-user 필터 적용됨: {string.Join(", ", includeUsers)}");
+
+                var included = participantIds.Where(u => includeUsers.Contains(u)).ToList();
+                var excluded = participantIds.Except(included).ToList();
+
+                Console.WriteLine($"[Dry-run] 분석에 포함될 사용자: {string.Join(", ", included)}");
+                Console.WriteLine($"[Dry-run] 분석에서 제외될 사용자: {string.Join(", ", excluded)}");
+            }
         }
 
         Console.WriteLine("\n===== 시뮬레이션 종료 =====");
@@ -196,7 +242,7 @@ CoconaApp.Run((
             }
             if (formats.Contains("chart"))
             {
-                // generator.GenerateChart();
+                //generator.GenerateChart();
                 Console.WriteLine("chart 생성이 오류가 나서 주석처리 해놓았습니다. 관련 이슈 PR 작업할 분들은 이 코드 바로 위에 줄 주석 풀고 진행해 주세요.");
             }
             if (formats.Contains("html"))


### PR DESCRIPTION
### ISSUE_ID
#324

### ISSUE_TITLE
dry-run 모드에서 --include-user 옵션이 적용되지 않음

###  기준 커밋 (Specify version - commit id)
27137bc151582217bb60df43ffa7340fc2f56339

### 변경사항
- [x] dry-run 모드에서도 `--include-user` 필터가 적용되도록 로직 추가
- [x] dry-run 내부에서도 `RepoDataCollector.CreateClient(token)`을 호출하도록 수정
- [x] 잘못된 저장소 인자에 대한 형식 검사 및 무시 처리 개선
<img width="1402" alt="스크린샷 2025-06-09 17 09 21" src="https://github.com/user-attachments/assets/03a83e8d-0dd4-40cc-ae2d-f378874784c3" />