### PR TITLE
콘솔 컬러 및 강조 출력 기능 추가

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,7 +20,9 @@ CoconaApp.Run((
     // ─────────────────────────────────────────────────────────────
     if (dryRun)
     {
+        Console.ForegroundColor = ConsoleColor.Yellow;
         Console.WriteLine("===== Dry-Run 시뮬레이션 =====");
+        Console.ResetColor();
         Console.WriteLine("분석 대상 저장소 목록:");
         foreach (var repoPath in repos)
         {
@@ -212,7 +214,9 @@ CoconaApp.Run((
     // 전체 저장소 요약 테이블 출력
     if (summaries.Count > 0)
     {
+        Console.ForegroundColor = ConsoleColor.Cyan;
         Console.WriteLine("\n📊 전체 저장소 요약 통계");
+        Console.ResetColor();
         Console.WriteLine("----------------------------------------------------");
         Console.WriteLine($"{"Repo",-30} {"B/F",5} {"Doc",5} {"typo",5}");
         Console.WriteLine("----------------------------------------------------");
@@ -226,7 +230,9 @@ CoconaApp.Run((
     // ❗ 실패 저장소 요약 출력
     if (failedRepos.Count > 0)
     {
+        Console.ForegroundColor = ConsoleColor.Red;
         Console.WriteLine("\n❌ 처리되지 않은 저장소 목록:");
+        Console.ResetColor();
         foreach (var r in failedRepos)
         {
             Console.WriteLine($"- {r} (올바른 형식: owner/repo)");
@@ -286,7 +292,9 @@ static (string, string)? TryParseRepoPath(string repoPath)
     var parts = repoPath.Split('/');
     if (parts.Length != 2)
     {
+        Console.ForegroundColor = ConsoleColor.Red;
         Console.WriteLine($"⚠️ 저장소 인자 '{repoPath}'는 'owner/repo' 형식이어야 합니다. (예: oss2025hnu/reposcore-cs");
+        Console.ResetColor();
         return null;
     }
 

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -46,13 +46,15 @@ public class FileGenerator
         foreach (var (id, scores) in _scores.OrderByDescending(x => x.Value.total))
         {
             double prRate = (sumOfPR > 0) ? (scores.PR_doc + scores.PR_fb + scores.PR_typo) / sumOfPR * 100 : 0.0;
-    double isRate = (sumOfIs > 0) ? (scores.IS_doc + scores.IS_fb) / sumOfIs * 100 : 0.0;
+            double isRate = (sumOfIs > 0) ? (scores.IS_doc + scores.IS_fb) / sumOfIs * 100 : 0.0;
             string line =
                 $"{id},{scores.PR_fb},{scores.PR_doc},{scores.PR_typo},{scores.IS_fb},{scores.IS_doc},{prRate:F1},{isRate:F1},{scores.total}";
             writer.WriteLine(line);
         }
 
+        Console.ForegroundColor = ConsoleColor.Green;
         Console.WriteLine($"{filePath} 생성됨");
+        Console.ResetColor();
     }
     public void GenerateTable()
     {
@@ -87,7 +89,9 @@ public class FileGenerator
 
         // 파일 출력
         File.WriteAllText(filePath, table.ToMinimalString());
+        Console.ForegroundColor = ConsoleColor.Green;
         Console.WriteLine($"{filePath} 생성됨");
+        Console.ResetColor();
     }
 
     public void GenerateChart()
@@ -103,7 +107,7 @@ public class FileGenerator
 
         string[] names = labels.ToArray();
         double[] scores = values.ToArray();
-        
+
         // ✅ 간격 조절된 Position
         double spacing = 10; // 막대 간격
         double[] positions = Enumerable.Range(0, names.Length)
@@ -134,7 +138,9 @@ public class FileGenerator
 
         string outputPath = Path.Combine(_folderPath, $"{_repoName}_chart.png");
         plt.SavePng(outputPath, 1920, 1080);
+        Console.ForegroundColor = ConsoleColor.Green;
         Console.WriteLine($"✅ 차트 생성 완료: {outputPath}");
+        Console.ResetColor();
     }
 
 

--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -168,12 +168,16 @@ public class RepoDataCollector
         }
         catch (AuthorizationException)
         {
+            Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine("❗ 인증 실패: 올바른 토큰을 사용했는지 확인하세요.");
+            Console.ResetColor();
             Environment.Exit(1);
         }
         catch (NotFoundException)
         {
+            Console.ForegroundColor = ConsoleColor.Red;
             Console.WriteLine("❗ 저장소를 찾을 수 없습니다. owner/repo 이름을 확인하세요.");
+            Console.ResetColor();
             Environment.Exit(1);
         }
         catch (Exception ex)


### PR DESCRIPTION
### ISSUE_ID
#322 
### ISSUE_TITLE
콘솔 컬러 및 강조 출력 기능 추가

###  기준 커밋 (Specify version - commit id)
[dfafd38](https://github.com/INHYOYUN/reposcore-cs/commit/dfafd38a5707fc40c4d7ca0d4b0ed9584602da42)

### 변경사항
- 주요 콘솔 출력에 색상 추가 적용 (Console.ForegroundColor 사용)
- Program.cs: Dry-Run 시뮬레이션 / 요약 통계 / 저장소 인자 오류 / 실패 저장소 목록에 색상 적용
- RepoDataCollector.cs: API 호출 오류, 인증 실패, 저장소 없음, 알 수 없는 오류 메시지에 색상 적용
- FileGenerator.cs: csv / txt / 차트 생성 성공 메시지에 색상 적용


### 🧪 테스트 방법 (선택 사항)
<img width="461" alt="오픈소스테스트1" src="https://github.com/user-attachments/assets/70a30763-7542-4337-89e1-a49f5e980030" />
<img width="174" alt="오픈소스테스트2" src="https://github.com/user-attachments/assets/936338b3-5445-4567-b1b1-8206f5eb5c4f" />
<img width="247" alt="오픈소스테스트3" src="https://github.com/user-attachments/assets/ce047e28-07de-4a5b-b961-eb5500236e02" />
