### PR TITLE
dry-run 존재하지 않는 format 오류 설명

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -297,6 +297,7 @@ static List<string> checkFormat(string[] format)
             Console.WriteLine($"포맷 '{f}'에는 파일명으로 사용할 수 없는 문자가 포함되어 있습니다.");
             Console.WriteLine("포맷 이름에서 다음 문자를 사용하지 마세요: " +
                 string.Join(" ", invalidChars.Select(c => $"'{c}'")));
+            Console.WriteLine("\n⛔ 잘못된 옵션으로 인해 프로그램을 종료합니다. '--help' 옵션으로 사용법을 확인하세요.");
             Environment.Exit(1);
         }
 
@@ -309,13 +310,15 @@ static List<string> checkFormat(string[] format)
     // 유효하지 않은 포맷이 존재
     if (unValidFormats.Count != 0)
     {
-        Console.WriteLine("유효하지 않은 포맷이 존재합니다.");
-        Console.Write("유효하지 않은 포맷: ");
+        Console.WriteLine("❌ 오류: 유효하지 않은 출력 형식이 포함되어 있습니다.");
+        Console.WriteLine("입력한 형식 중 아래 항목은 지원되지 않습니다:");
         foreach (var unValidFormat in unValidFormats)
         {
             Console.Write($"{unValidFormat} ");
         }
-        Console.Write("\n");
+        Console.WriteLine("\n✅ 사용 가능한 출력 형식은 다음과 같습니다:");
+        Console.WriteLine("  text, csv, chart, html, all");
+        Console.Write("\n 잘못된 옵션으로 인해 종료합니다. '--help' 옵션으로 사용법을 확인하세요.");
         Environment.Exit(1);
     }
 


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/338
### ISSUE_TITLE
dry-run 모드에서도 존재하지 않는 format을 사용하면 예외가 발생하지 않음

###  기준 커밋 (Specify version - commit id)
bb44633a61386c4ebc859719e706a1d2fe963f98
### 변경사항
기존 짧고 부족한 오류 설명에서 오류 사유와 해결 방법을 출력하게 checkformat함수를 수정하였습니다.


### 💬 참고 사항 (선택 사항)
차트와 html은 미구현 상태이지만 오류 메세지에는 출력되도록 하였습니다.
