### PR TITLE
--include-user 적용 결과가 비어있을 경우 안내문 추가 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ CoconaApp.Run((
 ) =>
 {
     // ─────────────────────────────────────────────────────────────
-    // ①-0) dry-run일 경우: 실제 로직 실행 전 “시뮬레이션 로그” 출력 후 종료
+    // ①-0) dry-run일 경우: 실제 로직 실행 전 "시뮬레이션 로그" 출력 후 종료
     // ─────────────────────────────────────────────────────────────
     if (dryRun)
     {
@@ -199,6 +199,17 @@ CoconaApp.Run((
                 }
             }
             summaries.Add(($"{owner}/{repo}", labelCounts));
+
+            // 존재하지 않는 사용자에 대한 경고 메시지 출력
+            if (includeUsers != null && includeUsers.Length > 0)
+            {
+                var existingUsers = userActivities.Keys.ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var missingUsers = includeUsers.Where(u => !existingUsers.Contains(u)).ToList();
+                if (missingUsers.Any())
+                {
+                    Console.WriteLine($"⚠️ 다음 사용자는 {owner}/{repo} 저장소에서 찾을 수 없습니다: {string.Join(", ", missingUsers)}\n");
+                }
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/336

### ISSUE_TITLE
--include-user 옵션 적용 결과가 비어 있을 경우 안내 메시지 추가요청

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/de067afce16f39b24d29b60be73692586fc91a0c

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
--include-user 옵션에 입력한 사용자 이름이 출력 결과에 존재하지 않을 경우, 다음과 같은 경고문을 출력합니다.
![image](https://github.com/user-attachments/assets/fc8b241b-5c74-4bb9-87df-dbeac984a5bf)




