### PR TITLE
차트에서 x축이 음수로 시작하는 문제 수정 

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -253,8 +253,7 @@ CoconaApp.Run((
             }
             if (formats.Contains("chart"))
             {
-                //generator.GenerateChart();
-                Console.WriteLine("chart 생성이 오류가 나서 주석처리 해놓았습니다. 관련 이슈 PR 작업할 분들은 이 코드 바로 위에 줄 주석 풀고 진행해 주세요.");
+                generator.GenerateChart();
             }
             if (formats.Contains("html"))
             {

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -132,6 +132,10 @@ public class FileGenerator
         plt.XLabel("총 점수");
         plt.YLabel("사용자");
 
+        // x축 범위 설정
+        plt.Axes.Bottom.Min = 0;
+        plt.Axes.Bottom.Max = scores.Max() * 1.1; // 최대값의 110%까지 표시
+
         string outputPath = Path.Combine(_folderPath, $"{_repoName}_chart.png");
         plt.SavePng(outputPath, 1920, 1080);
         Console.WriteLine($"✅ 차트 생성 완료: {outputPath}");


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/319

### ISSUE_TITLE
[BUG] 차트에서 x축이 음수로 시작

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/2d9d1e6bd11af0f7aad7b0ec56f40f2e0696d5aa

### 변경사항
생성되는 차트의 x축이 음수부터 시작하는 문제를 수정했습니다.


![image](https://github.com/user-attachments/assets/bad6f4c4-4bff-4989-9dcf-7033ef9abb49)

