### PR TITLE
주차별 활동 필터링 기능 추가 (--since, --until 옵션)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,8 +17,8 @@ CoconaApp.Run((
     [Option("include-user", Description = "결과에 포함할 사용자 ID 목록", ValueName = "Include user's id")] string[]? includeUsers,
     [Option("since", Description = "이 날짜 이후의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "Start date")] string? since,
     [Option("until", Description = "이 날짜까지의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "End date")] string? until,
-    [Option("dry-run", Description = "실제 작업 없이 시뮬레이션 로그만 출력")] bool dryRun
-    [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath
+    [Option("dry-run", Description = "실제 작업 없이 시뮬레이션 로그만 출력")] bool dryRun,
+    [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath,
 ) =>
 {
     // ───────────────────────────────────────────────────────

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,8 @@ CoconaApp.Run((
     [Option('f', Description = "출력 형식 지정 (\"text\", \"csv\", \"chart\", \"html\", \"all\", default : \"all\")", ValueName = "Output format")] string[]? format,
     [Option('t', Description = "GitHub 액세스 토큰 입력", ValueName = "Github token")] string? token,
     [Option("include-user", Description = "결과에 포함할 사용자 ID 목록", ValueName = "Include user's id")] string[]? includeUsers,
+    [Option("since", Description = "이 날짜 이후의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "Start date")] string? since,
+    [Option("until", Description = "이 날짜까지의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "End date")] string? until,
     [Option("dry-run", Description = "실제 작업 없이 시뮬레이션 로그만 출력")] bool dryRun
 ) =>
 {
@@ -36,6 +38,16 @@ CoconaApp.Run((
 
         Console.WriteLine($"캐시 사용 여부: {(CACHE_ENABLED ? "Enabled" : "Disabled")}");
         Console.WriteLine();
+
+        if (!string.IsNullOrEmpty(since) || !string.IsNullOrEmpty(until))
+        {
+            Console.WriteLine("분석 기간:");
+            if (!string.IsNullOrEmpty(since))
+                Console.WriteLine($"  • 시작: {since}");
+            if (!string.IsNullOrEmpty(until))
+                Console.WriteLine($"  • 종료: {until}");
+            Console.WriteLine();
+        }
 
         Console.WriteLine("API 호출 예정 여부: Yes (GitHub API를 사용하여 데이터를 가져올 예정)");
         Console.WriteLine();
@@ -83,7 +95,7 @@ CoconaApp.Run((
             Dictionary<string, UserActivity> userActivities;
             try
             {
-                userActivities = collector.Collect(); // ✅ 실제 참여자 목록 가져오기
+                userActivities = collector.Collect(since: since, until: until); // ✅ 실제 참여자 목록 가져오기
             }
             catch (Exception ex)
             {
@@ -151,7 +163,7 @@ CoconaApp.Run((
         var collector = new RepoDataCollector(owner, repo);
 
         // 데이터 수집
-        var userActivities = collector.Collect();
+        var userActivities = collector.Collect(since: since, until: until);
 
         Console.WriteLine($"\n🔍 처리 중: {owner}/{repo}");
 

--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ CoconaApp.Run((
     [Option("since", Description = "이 날짜 이후의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "Start date")] string? since,
     [Option("until", Description = "이 날짜까지의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "End date")] string? until,
     [Option("dry-run", Description = "실제 작업 없이 시뮬레이션 로그만 출력")] bool dryRun,
-    [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath,
+    [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath
 ) =>
 {
     // ───────────────────────────────────────────────────────


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/52

### ISSUE_TITLE
주차별 활동 필터링 기능 추가 (--since, --until 옵션)

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/b69a6e9f16947b52206c3f3f09760e18b14c4e00

### 변경사항
다음 2개의 옵션을 추가하였습니다
--since : 입력날짜 이후부터 집계
--until : 입력날짜 이전까지 집계


### 💬 참고 사항 (선택 사항)
예시 : 2025.04.20 ~ 2025.05.10 기간만 분석
```
dotnet run oss2025hnu/reposcore-js  --until 2025-05-10 --since 2025-04-20
```
