### PR TITLE
사용자 Id를 이름으로 치환하는 기능 개발 요청

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -44,7 +44,7 @@ public class FileGenerator
         // 파일에 "# 점수 계산 기준…" 을 쓰면, 이 줄이 CSV 첫 줄로 나옵니다.
         writer.WriteLine("# 점수 계산 기준: PR_fb*3, PR_doc*2, PR_typo*1, IS_fb*2, IS_doc*1");
         // CSV 헤더
-        writer.WriteLine("UserId,f/b_PR,doc_PR,typo,f/b_issue,doc_issue,PR_rate,IS_rate,total");
+        writer.WriteLine("User,f/b_PR,doc_PR,typo,f/b_issue,doc_issue,total");
 
         // 내용 작성
         foreach (var (id, scores) in _scores.OrderByDescending(x => x.Value.total))


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/286

### ISSUE_TITLE
사용자 Id를 이름으로 치환하는 기능 개발 요청

###  기준 커밋 (Specify version - commit id)
45e0c706338038df7b49348549d0cf99c262549a

### 변경사항
--user-info 옵션을 사용해 json, csv 포멧의 파일을 입력받아, 사용자의 Id를 치환


### 🧪 테스트 방법 (선택 사항)
1. 예시 매핑 파일 생성 (`users.json`)
   ```json
   {
     "weeksun02": "최주혜"
   }
   ```
   프로젝트 루트에 `users.json` 이름으로 저장
2. 매핑 옵션으로 실행
   ```bash
   dotnet run -- oss2025hnu/reposcore-cs --user-info users.json
   ```
3. 결과 확인
   * `output/reposcore-cs.csv` 파일을 열어서,

     * `UserId` 대신 `사용자의 이름`, 다른 ID는 ID 그대로 표시되는지 확인



