### PR TITLE
차트의 x축, y축 라벨 영문으로 변경

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -137,8 +137,8 @@ public class FileGenerator
 
         plt.Axes.Left.TickGenerator = new NumericManual(positions, names);
         plt.Title($"Scores - {_repoName}");
-        plt.XLabel("총 점수");
-        plt.YLabel("사용자");
+        plt.XLabel("Total Score");
+        plt.YLabel("User");
 
         // x축 범위 설정
         plt.Axes.Bottom.Min = 0;


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/344

### ISSUE_TITLE
차트의 x축, y축 라벨 영문으로 변경

###  기준 커밋 (Specify version - commit id)
ac05d4988521d81364e747752b9d6b32ad876841

### 변경사항
현재 생성되는 차트의 x축, y축 라벨이 한글로 되어 있어, 차트 내 글자 깨짐 현상이 발생하고 있습니다.
FileGenerator.cs 140 ~ 141 라인을 다음과 같이 수정합니다.

        plt.XLabel("Total Score");
        plt.YLabel("User");