### PR TITLE
라벨 하드코딩 제거 및 전역 상수로 분리

### DIFF
--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -22,6 +22,11 @@ public class RepoDataCollector
     private readonly string _owner; // 분석 대상 저장소의 owner (예: oss2025hnu)
     private readonly string _repo; // 분석 대상 저장소의 이름 (예: reposcore-cs)
 
+    //수정에 용이하도록 수집데이터종류 전역변수화
+    private static readonly string[] FeatureLabels = { "bug", "enhancement" };
+    private static readonly string[] DocsLabels = { "documentation" };
+    private static readonly string TypoLabel = "typo";
+
     // 생성자에는 저장소 하나의 정보를 넘김
     public RepoDataCollector(string owner, string repo)
     {
@@ -165,11 +170,11 @@ public class RepoDataCollector
                 {
                     if (item.PullRequest.Merged) // 병합된 PR만 집계
                     {
-                        if (labelName == "bug" || labelName == "enhancement")
+                        if (FeatureLabels.Contains(labelName))
                             activity.PR_fb++;
-                        else if (labelName == "documentation")
+                        else if (DocsLabels.Contains(labelName))
                             activity.PR_doc++;
-                        else if (labelName == "typo")
+                        else if (labelName == TypoLabel)
                             activity.PR_typo++;
                     }
                 }
@@ -178,9 +183,9 @@ public class RepoDataCollector
                     if (item.State.Value.ToString() == "Open" ||
                         item.StateReason.ToString() == "completed") // 열려있거나 정상적으로 닫힌 이슈들만 집계
                     {
-                        if (labelName == "bug" || labelName == "enhancement")
+                        if (FeatureLabels.Contains(labelName))
                             activity.IS_fb++;
-                        else if (labelName == "documentation")
+                        else if (DocsLabels.Contains(labelName))
                             activity.IS_doc++;
 
                     }


### PR DESCRIPTION
### ISSUE_ID
 #238

### ISSUE_TITLE
분석 라벨 목록을 하드코딩 대신 설정 파일 또는 상수로 분리

###  기준 커밋 (Specify version - commit id)
8607a9171d46b25ec2737421c9de246db8c2cffe

### 변경사항
기존 PR/이슈 라벨 문자열("bug", "enhancement", "documentation", "typo")을
전역 상수로 추출하여 코드 중복을 제거하고 유지보수를 용이하게 했습니다.

- FeatureLabels, DocsLabels, TypoLabel로 분리
- 하드코딩 제거
- 기능 변경 없음 (리팩토링 목적)