### PR TITLE
Total.text 생성 기능 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -98,6 +98,20 @@ public class FileGenerator
         Console.WriteLine($"{filePath} 생성됨");
     }
 
+    public void GenerateTotalText(string outputPath)
+    {
+        var table = new ConsoleTable("이름", "PR_fb", "PR_doc", "PR_typo", "IS_fb", "IS_doc", "총점");
+
+        foreach (var (user, score) in _scores.OrderByDescending(x => x.Value.total))
+        {
+            table.AddRow(user, score.PR_fb, score.PR_doc, score.PR_typo, score.IS_fb, score.IS_doc, score.total);
+        }
+
+        string result = table.ToMinimalString();
+        File.WriteAllText(outputPath, result);
+        Console.WriteLine($"✅ 텍스트 결과 생성 완료: {outputPath}");
+    }
+
     public void GenerateChart()
     {
         var labels = new List<string>();
@@ -137,7 +151,7 @@ public class FileGenerator
 
         string[] names = labels.ToArray();
         double[] scores = values.ToArray();
-        
+
         // ✅ 간격 조절된 Position
         double spacing = 10; // 막대 간격
         double[] positions = Enumerable.Range(0, names.Length)


### PR DESCRIPTION
### ISSUE_ID
#356

### ISSUE_TITLE
Total.text 생성 기능 추가

###  기준 커밋 (Specify version - commit id)
9a5883ce251606894123ed100d477b459bf1f367

### 변경사항
- 여러 저장소의 UserScore 정보를 통합하여 total.txt로 출력하는 기능 추가

- FileGenerator.GenerateTotalText() 메서드 구현 및 출력 파일 포맷 정의

- Program.cs에서 totalScores 누적 및 루프 종료 후 output/total.txt 생성 처리 추가

아래 명령어 사용시 
```bash
dotnet run -- "oss2025hnu/reposcore-cs" "oss2025hnu/reposcore-py" "oss2025hnu/reposcore-js" --format text -t 토큰값
```
예시)
![image](https://github.com/user-attachments/assets/f805651c-3225-46fa-9776-7a1a7fe25f15)