### PR TITLE
예외 메시지를 명확하게 출력하고 종료

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -18,7 +18,17 @@ public class FileGenerator
         _scores = repoScores;
         _repoName = repoName;
         _folderPath = Path.Combine(folderPath, repoName);
-        Directory.CreateDirectory(_folderPath);
+
+        try
+        {
+            Directory.CreateDirectory(_folderPath);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"❗ 결과 디렉토리 생성에 실패했습니다. (경로: {_folderPath})");
+            Console.WriteLine($"→ 디스크 권한이나 경로 오류를 확인하세요: {ex.Message}");
+            Environment.Exit(1);
+        }
     }
 
     double sumOfPR


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/312

### ISSUE_TITLE
[BUG] 결과 디렉토리 생성 실패 시 예외 메시지 없이 조용히 종료되는 문제

###  기준 커밋 (Specify version - commit id)
491fe6f45691dc247099e7807a0e2df287ef6caa

### 변경사항
- 디렉토리 생성에 실패할 경우, 결과 디렉토리 생성에 실패 경고 메세지 출력

