### PR TITLE
차트 막대 오른쪽에 점수 표시

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -2,10 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Drawing;
 using ConsoleTables;
 using ScottPlot;
 using ScottPlot.Plottables;
 using ScottPlot.TickGenerators;
+using Alignment = ScottPlot.Alignment;
+using Color = System.Drawing.Color;
 
 public class FileGenerator
 {
@@ -119,6 +122,7 @@ public class FileGenerator
                                     .ToArray();
 
         // Bar 데이터 생성
+        var plt = new ScottPlot.Plot();
         var bars = new List<Bar>();
         for (int i = 0; i < scores.Length; i++)
         {
@@ -130,9 +134,14 @@ public class FileGenerator
                 Orientation = Orientation.Horizontal,
                 Size = 5,
             });
+
+            double textX = scores[i] + scores.Max() * 0.01;
+            double textY = positions[i];
+
+            var txt = plt.Add.Text($"{scores[i]:F1}", textX, textY);
+            txt.Alignment = Alignment.MiddleLeft;
         }
 
-        var plt = new ScottPlot.Plot();
         var barPlot = plt.Add.Bars(bars);
 
         plt.Axes.Left.TickGenerator = new NumericManual(positions, names);

--- a/reposcore-cs.csproj
+++ b/reposcore-cs.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="ScottPlot" Version="5.0.55" />
+    <PackageReference Include="System.Drawing.Common" Version="9.0.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/316

### ISSUE_TITLE
그래프의 맨 우측에 점수 추가

###  기준 커밋 (Specify version - commit id)
65a203784e7770070d562782966e2e57479ed675

### 변경사항
그래프 결과물의 그래프 막대 오른쪽에 각 점수가 표시되도록 수정
- 이에 필요한 System.Drawing.Common패키지도 추가

### 🧪 테스트 방법 (선택 사항)
1. 저장소 분석
2. 결과 확인