### PR TITLE
API 호출 진행률 표시 기능 추가 (--progress 옵션)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A CLI for scoring student participation in an open-source class repo, implemente
 아래는 `dotnet run -- -h` 또는 `dotnet run -- -help`실행 결과를 붙여넣은 것이므로 명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
 
 ```bash
-Usage: reposcore-cs [--verbose] [--output <Output directory>] [--format <Output format>...] [--token <Github token>] [--include-user <Include user's id>...] [--help] [--version] repos0 ... reposN
+Usage: reposcore-cs [--verbose] [--output <Output directory>] [--format <Output format>...] [--token <Github token>] [--include-user <Include user's id>...] [--progress] [--help] [--version] repos0 ... reposN
 
 reposcore-cs
 
@@ -20,6 +20,7 @@ Options:
   -f, --format <Output format>...          출력 형식 지정 ("text", "csv", "chart", "html", "all", default : "all")
   -t, --token <Github token>               GitHub 액세스 토큰 입력
   --include-user <Include user's id>...    결과에 포함할 사용자 ID 목록
+  --progress                               API 호출 진행률을 표시합니다.
   -h, --help                               Show help message
   --version                                Show version
 ```


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/326

### ISSUE_TITLE
API 호출 진행률 표시 기능 추가 (--progress 옵션)

### 기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/65a203784e7770070d562782966e2e57479ed675

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- `--progress` 명령줄 옵션 추가
- 여러 저장소 처리 시 현재 진행률 `(N/Total)` 표시
- API 호출 등 시간이 걸리는 작업에 대한 실시간 상태 업데이트 (예: '불러오는 중...')

### 🧪 테스트 방법 (선택 사항)
1.  `--progress` 옵션을 사용하여 실행하고, 진행률 메시지가 정상적으로 표시되는지 확인합니다.
    ```bash
    dotnet run -- oss2025hnu/reposcore-py oss2025hnu/reposcore-js oss2025hnu/reposcore-cs --progress
    ```
2. ```bash 
     출력 디렉토리가 지정되지 않아 기본 경로 'output/'이 사용됩니다.
      .env의 토큰을 갱신합니다.
      ▶ 전체(1/3) PR 및 Issue 불러오는 중... OK..
      output/reposcore-py/reposcore-py.csv 생성됨
      output/reposcore-py/reposcore-py1.txt 생성됨
      ✅ 차트 생성 완료: output/reposcore-py/reposcore-py_chart.png
      html 파일 생성이 아직 구현되지 않았습니다.
      ▶ 처리 중 (1/3): oss2025hnu/reposcore-py 완료
      ▶ 전체(2/3) PR 및 Issue 불러오는 중... OK..
      output/reposcore-js/reposcore-js.csv 생성됨
      output/reposcore-js/reposcore-js1.txt 생성됨
      ✅ 차트 생성 완료: output/reposcore-js/reposcore-js_chart.png
      html 파일 생성이 아직 구현되지 않았습니다.
      ▶ 처리 중 (2/3): oss2025hnu/reposcore-js 완료
      ▶ 전체(3/3) PR 및 Issue 불러오는 중... OK..
      output/reposcore-cs/reposcore-cs.csv 생성됨
      output/reposcore-cs/reposcore-cs1.txt 생성됨
      ✅ 차트 생성 완료: output/reposcore-cs/reposcore-cs_chart.png
      html 파일 생성이 아직 구현되지 않았습니다.
      ▶ 처리 중 (3/3): oss2025hnu/reposcore-cs 완료
      ✅ 차트 생성 완료: output/total/total_chart.png
      완료
```bash