### PR TITLE
차트 막대 별 "총점 / 세부 점수" 텍스트 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -178,8 +178,22 @@ public class FileGenerator
             double textX = scores[i] + scores.Max() * 0.01;
             double textY = positions[i];
 
-            var txt = plt.Add.Text($"{scores[i]:F1}", textX, textY);
-            txt.Alignment = Alignment.MiddleLeft;
+            // 사용자 이름 추출 (labels와 rankList는 같은 순서)
+            var userLabel = labels[i];
+            // userLabel은 "user (1st)" 형태이므로, rankList에서 사용자 이름을 가져옴
+            var userName = rankList.OrderBy(x => x.Score).ElementAt(i).User;
+            if (_scores.TryGetValue(userName, out var userScore))
+            {
+                string detailText = $"{userScore.total} (PR_fb {userScore.PR_fb} / PR_doc {userScore.PR_doc} / PR_typo {userScore.PR_typo} / IS_fb {userScore.IS_fb} / IS_doc {userScore.IS_doc})";
+                var txt = plt.Add.Text(detailText, textX, textY);
+                txt.Alignment = Alignment.MiddleLeft;
+            }
+            else
+            {
+                // 혹시라도 매칭이 안 될 경우 기존 총점만 표시
+                var txt = plt.Add.Text($"{scores[i]:F1}", textX, textY);
+                txt.Alignment = Alignment.MiddleLeft;
+            }
         }
 
         var barPlot = plt.Add.Bars(bars);
@@ -191,7 +205,7 @@ public class FileGenerator
 
         // x축 범위 설정
         plt.Axes.Bottom.Min = 0;
-        plt.Axes.Bottom.Max = scores.Max() * 1.1; // 최대값의 110%까지 표시
+        plt.Axes.Bottom.Max = scores.Max() * 2; // 최대값의 110%까지 표시
 
         string outputPath = Path.Combine(_folderPath, $"{_repoName}_chart.png");
         plt.SavePng(outputPath, 1080, 1920);

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -205,7 +205,7 @@ public class FileGenerator
 
         // x축 범위 설정
         plt.Axes.Bottom.Min = 0;
-        plt.Axes.Bottom.Max = scores.Max() * 2; // 최대값의 110%까지 표시
+        plt.Axes.Bottom.Max = scores.Max() * 2; 
 
         string outputPath = Path.Combine(_folderPath, $"{_repoName}_chart.png");
         plt.SavePng(outputPath, 1080, 1920);


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/379

### ISSUE_TITLE
차트 오른쪽에 "총점 / 세부 점수" 텍스트 추가

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/f3ff81a1837956a063060409d07b2e61a7e3cf62

### 변경사항
차트 막대별 총점, 세부점수를 표시했습니다.

![image](https://github.com/user-attachments/assets/2d6ea94d-117d-476e-b9cc-10951b048717)

