### PR TITLE
반려된 이슈 제외: 받아들여진 이슈만 점수 합산

### DIFF
--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -141,6 +141,12 @@ public class RepoDataCollector
                 allIssuesAndPRs = allIssuesAndPRs.Where(issue => issue.CreatedAt <= untilDate).ToList();
             }
 
+            // 반려 처리할 라벨 목록
+            var rejectionLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "wontfix", "invalid", "duplicate"
+            };
+
             // 수집용 mutable 객체. 모든 데이터 수집 후 레코드로 변환하여 반환
             var mutableActivities = new Dictionary<string, UserActivity>();
 
@@ -148,6 +154,10 @@ public class RepoDataCollector
             foreach (var item in allIssuesAndPRs)
             {
                 if (item.User?.Login == null) continue;
+
+                 // 반려된 이슈/PR은 점수 집계에서 제외
+                if (item.Labels.Any(l => rejectionLabels.Contains(l.Name)))
+                    continue;
 
                 var username = item.User.Login;
 


### PR DESCRIPTION
ISSUE_ID
#347 

ISSUE_TITLE
닫힌 이슈 중 "wontfix", "invalid", "duplicate" 라벨이 붙은 이슈를 점수 계산에서 제외

기준 커밋 (Specify version - commit id)
f3ff81a

변경사항
 RepoDataCollector.Collect() 메서드 내에서 반려 라벨(wontfix, invalid, duplicate)을 필터링하는 로직 추가

 labelNames.Overlaps(rejectionLabels) 조건으로 불필요한 이슈 제외







