### PR TITLE
차트 우측 상단 평균, 최대, 최소 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -205,7 +205,29 @@ public class FileGenerator
 
         // x축 범위 설정
         plt.Axes.Bottom.Min = 0;
-        plt.Axes.Bottom.Max = scores.Max() * 2; 
+        plt.Axes.Bottom.Max = scores.Max() * 2.5; 
+
+        // 통계 정보 추가
+        double maxScore = scores.Max();
+        double minScore = scores.Min();
+        double avgScore = scores.Average();
+
+        // 제목 근처에 통계 정보 표시
+        double xRight = scores.Max() * 2.4; // x축 최대값의 90% 위치
+        double yTop = positions[^3] + spacing * 2; // 마지막 막대 위에 표시
+        double ySpacing = spacing * 0.8; // 텍스트 간격
+
+        var maxText = plt.Add.Text($"max: {maxScore:F1}", xRight, yTop);
+        maxText.Alignment = Alignment.UpperRight;
+        maxText.Color = Colors.DarkGreen;
+
+        var avgText = plt.Add.Text($"avg: {avgScore:F1}", xRight, yTop - ySpacing);
+        avgText.Alignment = Alignment.UpperRight;
+        avgText.Color = Colors.DarkBlue;
+
+        var minText = plt.Add.Text($"min: {minScore:F1}", xRight, yTop - ySpacing * 2);
+        minText.Alignment = Alignment.UpperRight;
+        minText.Color = Colors.DarkRed;
 
         string outputPath = Path.Combine(_folderPath, $"{_repoName}_chart.png");
         plt.SavePng(outputPath, 1080, 1920);


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/320

### ISSUE_TITLE
차트의 우측 상단에 평균, 최대, 최소 점수 표시

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/1de797d6154073c4775f0c1923ad1ad401402386

### 변경사항
생성되는 차트 우측 상단에 최대값, 최소값, 평균값을 출력하도록 수정하였습니다.


![image](https://github.com/user-attachments/assets/8f0e7c74-b242-421a-b456-66c58e4bccfb)

