### PR TITLE
--user 옵션으로 특정 사용자의 점수 및 순위만 출력 PR

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,7 @@ CoconaApp.Run((
     [Option('f', Description = "출력 형식 지정 (\"text\", \"csv\", \"chart\", \"html\", \"all\", default : \"all\")", ValueName = "Output format")] string[]? format,
     [Option('t', Description = "GitHub 액세스 토큰 입력", ValueName = "Github token")] string? token,
     [Option("include-user", Description = "결과에 포함할 사용자 ID 목록", ValueName = "Include user's id")] string[]? includeUsers,
+    [Option("user", Description = "특정 사용자 한 명의 점수와 순위만 출력합니다.", ValueName = "Username")] string? singleUser,
     [Option("since", Description = "이 날짜 이후의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "Start date")] string? since,
     [Option("until", Description = "이 날짜까지의 PR 및 이슈만 분석 (YYYY-MM-DD)", ValueName = "End date")] string? until,
     [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath,
@@ -159,18 +160,21 @@ CoconaApp.Run((
                 }
             }
 
-            List<string> formats = (format == null || format.Length == 0)
-                ? new List<string> { "text", "csv", "chart", "html" }
-                : checkFormat(format);
+            if (string.IsNullOrEmpty(singleUser))
+            {
+                List<string> formats = (format == null || format.Length == 0)
+                    ? new List<string> { "text", "csv", "chart", "html" }
+                    : checkFormat(format);
 
-            string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
-            var generator = new FileGenerator(finalScores, repo, outputDir);
+                string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
+                var generator = new FileGenerator(finalScores, repo, outputDir);
 
-            if (formats.Contains("csv")) generator.GenerateCsv();
-            if (formats.Contains("text")) generator.GenerateTable();
-            if (formats.Contains("chart")) generator.GenerateChart();
-            if (formats.Contains("html")) generator.GenerateHtml();
-            if (showStateSummary) generator.GenerateStateSummary(collector.StateSummary);
+                if (formats.Contains("csv")) generator.GenerateCsv();
+                if (formats.Contains("text")) generator.GenerateTable();
+                if (formats.Contains("chart")) generator.GenerateChart();
+                if (formats.Contains("html")) generator.GenerateHtml();
+                if (showStateSummary) generator.GenerateStateSummary(collector.StateSummary);
+            }
         }
         catch (Exception ex)
         {
@@ -181,13 +185,51 @@ CoconaApp.Run((
             Console.WriteLine($"▶ 처리 중 ({repoIndex}/{totalRepos}): {owner}/{repo} 완료");
     }
 
-    // 🆕 totalChart 출력
-    if (totalScores.Count > 0)
+    if (string.IsNullOrEmpty(singleUser) && totalScores.Count > 0)
     {
         string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
         var totalGen = new FileGenerator(totalScores, "total", outputDir);
         totalGen.GenerateChart();
     }
+    // --user 옵션이 지정된 경우, 해당 사용자의 점수와 순위만 출력
+    else if (!string.IsNullOrEmpty(singleUser) && totalScores.Count > 0)
+    {
+        var sortedScores = totalScores.OrderByDescending(x => x.Value.total).ToList();
+        int rank = 1;
+        int prevScore = -1;
+        int actualRank = 1;
+
+        UserScore? targetUserScore = null;
+        int targetUserRank = 0;
+
+        foreach (var entry in sortedScores)
+        {
+            if (entry.Value.total != prevScore)
+            {
+                rank = actualRank;
+            }
+
+            if (string.Equals(entry.Key, singleUser, StringComparison.OrdinalIgnoreCase))
+            {
+                targetUserScore = entry.Value;
+                targetUserRank = rank;
+                break;
+            }
+
+            prevScore = entry.Value.total;
+            actualRank++;
+        }
+
+        if (targetUserScore != null)
+        {
+            Console.WriteLine($"{singleUser} 사용자의 총점: {targetUserScore.total}점, 순위: {targetUserRank}위");
+        }
+        else
+        {
+            Console.WriteLine($"'{singleUser}' 사용자를 찾을 수 없습니다.");
+        }
+    }
+
 
     if (failedRepos.Count > 0)
     {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/294

### ISSUE_TITLE
--user 옵션으로 특정 사용자의 점수 및 순위만 출력

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/042a7a170c029470b221b2c7f4ad540f3687e178

### 변경사항
1. `--user` 옵션을 추가하여 단일 GitHub 사용자 ID를 입력받도록 함.
2. `--user` 옵션이 지정된 경우, CSV, Text, Chart, HTML 등 기존의 전체 보고서 파일 생성을 건너뛰도록 처리.

### 🧪 테스트 방법 (선택 사항)
`dotnet run -- oss2025hnu/reposcore-py oss2025hnu/reposcore-js oss2025hnu/reposcore-cs --user [사용자]`
