### PR TITLE
GitHub API 호출 실패 시 자동 재시도 및 백오프 로직 추가

### DIFF
--- a/Reposcore/RepoDataCollector.cs
+++ b/Reposcore/RepoDataCollector.cs
@@ -166,11 +166,11 @@ public class RepoDataCollector
             }
         }
 
-        // --- Retry + Backoff 로직 시작 ---
+        // --- Retry + Backoff 로직 추가 ---
         int maxRetries = 3;
         int[] backoffSeconds = { 1, 2, 4 };
 
-        for (int attempt = 0; attempt <= maxRetries; attempt++)
+        for (int attempt = 0; attempt < maxRetries; attempt++)
         {
             try
             {
@@ -250,18 +250,18 @@ public class RepoDataCollector
                 SaveToCache(userActivities);
                 return userActivities;
             }
-            catch (Exception ex) when (attempt < maxRetries)
+            catch (Exception ex)
             {
                 PrintHelper.PrintWarning($"⚠️ API 요청 실패, 재시도 시도 ({attempt + 1}/{maxRetries}) - {ex.Message}");
+
+                if (attempt == maxRetries - 1)
+                    throw;
+
                 System.Threading.Thread.Sleep(backoffSeconds[attempt] * 1000);
-            }
-            catch
-            {
-                throw;
             }
         }
 
-        // 모든 재시도 실패 시 마지막으로 예외 발생
-        throw new Exception($"API 요청이 {maxRetries + 1}회 모두 실패했습니다: {_owner}/{_repo}");
+        // 정상 실행 도달 불가 (논리상)
+        throw new Exception("재시도 실패");
     }
 }


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/223

### ISSUE_TITLE
GitHub API 호출 실패 시 자동 재시도 및 백오프 로직 추가

###  기준 커밋 (Specify version - commit id)
24bd3468c1f0543bfbf3c23d93b3bb7e0114bc3b

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
- [  API 요청 실패 시 최대 3회 재시도 로직 추가 ] 변경 사항 1
- [ 재시도 간격: 1초 → 2초 → 4초 백오프 적용 ] 변경 사항 2
- [ ] 변경 사항 3

### 🧪 테스트 방법 (선택 사항)
잘못된 저장소를 입력하여 재시도 동작 확인
![스크린샷 2025-06-15 161314](https://github.com/user-attachments/assets/51672a4e-b819-4e20-bfc5-641fe3f1e59d)

### 💬 참고 사항 (선택 사항)
기존 RepoDataCollector.cs 파일에서 Collect() 메서드에만 기능 추가됨