### PR TITLE
ScoreAnalyzer 클래스의 생성자와 Analyze 메소드 작성

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -133,32 +133,9 @@ CoconaApp.Run((
 
         try
         {
-            var rawScores = userActivities.ToDictionary(pair => pair.Key, pair => ScoreAnalyzer.FromActivity(pair.Value));
-            var finalScores = idToNameMap != null
-                ? rawScores.ToDictionary(
-                    kvp => idToNameMap.TryGetValue(kvp.Key, out var name) ? name : kvp.Key,
-                    kvp => kvp.Value,
-                    StringComparer.OrdinalIgnoreCase)
-                : rawScores;
-
-            // 🆕 total score 누적
-            foreach (var (user, score) in finalScores)
-            {
-                if (!totalScores.ContainsKey(user))
-                    totalScores[user] = score;
-                else
-                {
-                    var prev = totalScores[user];
-                    totalScores[user] = new UserScore(
-                        prev.PR_fb + score.PR_fb,
-                        prev.PR_doc + score.PR_doc,
-                        prev.PR_typo + score.PR_typo,
-                        prev.IS_fb + score.IS_fb,
-                        prev.IS_doc + score.IS_doc,
-                        prev.total + score.total
-                    );
-                }
-            }
+            var analyzer = new ScoreAnalyzer(userActivities, idToNameMap);
+            var scores = analyzer.Analyze();
+            totalScores = analyzer.TotalAnalyze(scores);
 
             if (string.IsNullOrEmpty(singleUser))
             {
@@ -167,7 +144,7 @@ CoconaApp.Run((
                     : checkFormat(format);
 
                 string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
-                var generator = new FileGenerator(finalScores, repo, outputDir);
+                var generator = new FileGenerator(scores, repo, outputDir);
 
                 if (formats.Contains("csv")) generator.GenerateCsv();
                 if (formats.Contains("text")) generator.GenerateTable();

--- a/Reposcore/ScoreAnalyzer.cs
+++ b/Reposcore/ScoreAnalyzer.cs
@@ -5,9 +5,54 @@ public class ScoreAnalyzer
     public const int P_T = 1;
     public const int I_FB = 2;
     public const int I_D = 1;
+    private readonly Dictionary<string, UserActivity> _userActivities;
+    private readonly Dictionary<string, string>? _idToNameMap;
+    
+    public ScoreAnalyzer(Dictionary<string, UserActivity> userActivities, Dictionary<string, string>? idToNameMap)
+    {
+        _userActivities = userActivities;
+        _idToNameMap = idToNameMap;
+    }
 
+    // total scores 누적
+    public Dictionary<string, UserScore> TotalAnalyze(Dictionary<string, UserScore> scores)
+    {
+        var totalScores = new Dictionary<string, UserScore>();
+        // 🆕 total score 누적
+        foreach (var (user, score) in scores)
+        {
+            if (!totalScores.ContainsKey(user))
+                totalScores[user] = score;
+            else
+            {
+                var prev = totalScores[user];
+                totalScores[user] = new UserScore(
+                    prev.PR_fb + score.PR_fb,
+                    prev.PR_doc + score.PR_doc,
+                    prev.PR_typo + score.PR_typo,
+                    prev.IS_fb + score.IS_fb,
+                    prev.IS_doc + score.IS_doc,
+                    prev.total + score.total
+                );
+            }
+        }
+        return totalScores;
+    }
 
-    public static UserScore FromActivity(UserActivity act)
+    public Dictionary<string, UserScore> Analyze()
+    {
+        var rawScores = _userActivities.ToDictionary(pair => pair.Key, pair => FromActivity(pair.Value));
+        var finalScores = _idToNameMap != null
+                ? rawScores.ToDictionary(
+                    kvp => _idToNameMap.TryGetValue(kvp.Key, out var name) ? name : kvp.Key,
+                    kvp => kvp.Value,
+                    StringComparer.OrdinalIgnoreCase)
+                : rawScores;
+
+        return finalScores;
+    }
+
+    private static UserScore FromActivity(UserActivity act)
     {
         var (p_fb, p_d, p_t, i_fb, i_d) = act;
 


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/291

### ISSUE_TITLE
ScoreAnalyzer 클래스의 생성자와 Analyze 메소드 작성

###  기준 커밋 (Specify version - commit id)
a259c9f1ce2002d382ed29ff18ad99418434f95f

### 변경사항
- [ ] 변경 사항 1
`ScoreAnalyzer` 클래스에 생성자 추가
생성자에는 유저별 활동수의`userActivities`와 id -> 이름 치환을 위한 `idToNameMap` 전달
- [ ] 변경 사항 2
`Analyze` 메소드 작성
기존 `Program.cs`에 작성되어있던 코드를 메소드로 구현, `FromActivity` 메소드를 private으로 변경
- [ ] 변경 사항 3
total scores 값을 반환하는 `TotalAnalyze` 메소드 작성