### PR TITLE
저장소가 2개 이상일 경우에만 total 폴더 생성

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -162,7 +162,7 @@ CoconaApp.Run((
             PrintHelper.PrintInfo($"▶ 처리 중 ({repoIndex}/{totalRepos}): {owner}/{repo} 완료");
     }
 
-    if (string.IsNullOrEmpty(singleUser) && totalScores.Count > 0)
+    if (string.IsNullOrEmpty(singleUser) && totalScores.Count > 0 && repos.Length > 1)
     {
         string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
         var totalGen = new FileGenerator(totalScores, "total", outputDir);


### PR DESCRIPTION
### ISSUE_ID
#397 

### ISSUE_TITLE
[BUG] 저장소가 1개일 경우에도 Total 분석이 생성됨

###  기준 커밋 (Specify version - commit id)
42e994d

### 변경사항
저장소 개수가 2개 이상일 때만 total 폴더 및 파일이 생성되도록 조건을 추가했습니다.
저장소가 1개일 때는 total 폴더가 생성되지 않습니다.