### PR TITLE
HTML의 Total 탭을 첫 번째에 표시

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -312,13 +312,13 @@ public class FileGenerator
         writer.WriteLine("        </ul>");
         writer.WriteLine("    </div>");
 
-        // 탭 버튼
+        // 탭 버튼 - Total을 첫 번째로 이동
         writer.WriteLine("    <div class='tab'>");
+        writer.WriteLine("        <button class='tablinks active' onclick=\"openTab(event, 'total')\">Total</button>");
         foreach (var (repoName, _) in _allRepos)
         {
             writer.WriteLine($"        <button class='tablinks' onclick=\"openTab(event, '{repoName}')\">{repoName}</button>");
         }
-        writer.WriteLine("        <button class='tablinks' onclick=\"openTab(event, 'total')\">Total</button>");
         writer.WriteLine("    </div>");
 
         // 각 저장소별 탭 내용


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/396

### ISSUE_TITLE
HTML의 Total 탭을 첫 번째에 표시

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/0227e116cd4d606bb766def34cb0fd24ce7ea90b

### 변경사항
- Total 탭을 왼쪽 첫 번째로 이동
- 페이지 로드 시 Total 탭이 기본으로 선택되도록 수정
- 중복된 Total 탭 버튼 제거
