### PR TITLE
불필요한 using 삭제

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -2,13 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Drawing;
 using ConsoleTables;
 using ScottPlot;
 using ScottPlot.Plottables;
 using ScottPlot.TickGenerators;
 using Alignment = ScottPlot.Alignment;
-using Color = System.Drawing.Color;
 
 public class FileGenerator
 {


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/417

### ISSUE_TITLE
불필한 using제거

###  기준 커밋 (Specify version - commit id)
734c6a17a2d5635fe6c6c4332f8af0a3323e4fe4

### 변경사항
FileGenerator.cs에서는 현재 코드 3줄의 경고에 대해
Color -> LabelFontColor로 변경하는 이슈가 진행중입니다.
이에 따라 불필요해지는 using
```bash
using System.Drawing;
using Color = System.Drawing.Color;
```
위 두개의 using을 삭제했습니다.