### PR TITLE
저장소별 참여자 수를 함께 표시하는 기능 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -16,6 +16,7 @@ public class FileGenerator
     private readonly string _repoName;
     private readonly string _folderPath;
     private static List<(string RepoName, Dictionary<string, UserScore> Scores)> _allRepos = new();
+    private int ParticipantCount => _scores.Count; //참여자 수 프로퍼티 추가
 
     public FileGenerator(Dictionary<string, UserScore> repoScores, string repoName, string folderPath)
     {
@@ -68,7 +69,9 @@ public class FileGenerator
         double avg = totals.Count > 0 ? totals.Average() : 0.0;
         double max = totals.Count > 0 ? totals.Max() : 0.0;
         double min = totals.Count > 0 ? totals.Min() : 0.0;
-        writer.WriteLine($"# Repo: {_repoName}  Date: {now}  Avg: {avg:F1}  Max: {max:F1}  Min: {min:F1}");
+        writer.WriteLine($"# Repo: {_repoName}  Date: {now}  Avg: {avg:F1}  Max: {max:F1}  Min: {min:F1}"); 
+        writer.WriteLine($"# 참여자 수: {_scores.Count}명"); //참여자 수 출력 추가가
+
 
         // 내용 작성
         foreach (var (id, scores) in _scores.OrderByDescending(x => x.Value.total))
@@ -123,12 +126,16 @@ public class FileGenerator
         double max = totals.Count > 0 ? totals.Max() : 0.0;
         double min = totals.Count > 0 ? totals.Min() : 0.0;
         string metaLine = $"# Repo: {_repoName}  Date: {now}  Avg: {avg:F1}  Max: {max:F1}  Min: {min:F1}";
+        string participantLine = $"# 참여자 수: {_scores.Count}명"; //참여자 수 출력 추
 
         var content = "# 점수 계산 기준: PR_fb*3, PR_doc*2, PR_typo*1, IS_fb*2, IS_doc*1"
                     + Environment.NewLine
                     + metaLine
                     + Environment.NewLine
+                    + participantLine //추가
+                    + Environment.NewLine
                     + tableText;
+                    
 
         File.WriteAllText(filePath, content);
         Console.WriteLine($"{filePath} 생성됨");
@@ -325,6 +332,7 @@ public class FileGenerator
         foreach (var (repoName, scores) in _allRepos)
         {
             writer.WriteLine($"    <div id='{repoName}' class='tabcontent'>");
+            writer.WriteLine($"        <p>참여자 수: {scores.Count}명</p>"); //참여자 수 출력 추
             writer.WriteLine("        <table>");
             writer.WriteLine("            <thead>");
             writer.WriteLine("                <tr>");


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/443

### ISSUE_TITLE
<!-- 관련된 이슈 제목을 입력해주세요 -->
저장소별 참여자 수를 함께 표시하는 기능 추가

###  기준 커밋 (Specify version - commit id)
<!-- 변경 사항이 반영된 기준 커밋 ID를 입력해주세요 (예: 0e34a8b) -->
38f3db9e06bce2cd7e44d75e3031a571c59ba649

### 변경사항
<!-- 이번 PR에서 변경된 주요 내용을 간단히 작성해주세요 -->
저장소별 **참여자 수 표시 기능**을 추가했습니다.  
기존 출력 포맷(CSV, 텍스트 테이블, HTML)에 다음과 같이 참여자 수를 명시합니다.
- `FileGenerator` 클래스에 `ParticipantCount` 프로퍼티 추가 (`_scores.Count` 기반)
- **CSV 출력 (`GenerateCsv`)**
  - 상단 메타 정보에 `# 참여자 수: N명` 추가
- **텍스트 테이블 출력 (`GenerateTable`)**
  - 메타 정보 블록에 `# 참여자 수: N명` 추가
- **HTML 출력 (`GenerateHtml`)**
  - 각 저장소 탭 콘텐츠 상단에 `<p>참여자 수: N명</p>` 추가
