### PR TITLE
차트에 max, avg, min 이 불필요하게 두 곳에 표기됨

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -222,7 +222,7 @@ public class FileGenerator
         double max = scores.Max();
         double min = scores.Min();
 
-        string chartTitle = $"Repo: {_repoName}  Date: {now}  Avg: {avg:F1}  Max: {max:F1}  Min: {min:F1}";
+        string chartTitle = $"Repo: {_repoName}  Date: {now}";
         plt.Axes.Left.TickGenerator = new NumericManual(positions, names);
         plt.Title($"Scores - {_repoName}" + "\n" + chartTitle);
         plt.XLabel("Total Score");


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/438

### ISSUE_TITLE
차트에 max, avg, min 이 불필요하게 두 곳에 표기됨

###  기준 커밋 (Specify version - commit id)
734c6a17a2d5635fe6c6c4332f8af0a3323e4fe4

### 변경사항
차트 재목 옆과 차트 내부에 max, avg, min이 중복되어 나타나고 있으므로 제목에 있는 항목을 수정하여 중복 문제를 해결.