### PR TITLE
저장소 분석 시 생성되는 html 파일에 타임스탬프 추가

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -296,9 +296,11 @@ public class FileGenerator
         writer.WriteLine("        .tab button:hover { background-color: #ddd; }");
         writer.WriteLine("        .tab button.active { background-color: #ccc; }");
         writer.WriteLine("        .tabcontent { display: none; padding: 6px 12px; border: 1px solid #ccc; border-top: none; }");
+        writer.WriteLine("        .timestamp { color: #666; margin: 10px 0; text-align: right; }");
         writer.WriteLine("    </style>");
         writer.WriteLine("</head>");
         writer.WriteLine("<body>");
+        writer.WriteLine($"    <div class='timestamp'>생성 시간: {DateTime.Now:yyyy-MM-dd HH:mm:ss}</div>");
 
         // 점수 계산 기준 정보
         writer.WriteLine("    <div class='score-info'>");


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/414

### ISSUE_TITLE
저장소 분석 시 생성되는 html 파일에 타임스탬프 추가

###  기준 커밋 (Specify version - commit id)
https://github.com/oss2025hnu/reposcore-cs/commit/734c6a17a2d5635fe6c6c4332f8af0a3323e4fe4

### 변경사항
- HTML 파일에 생성 시간을 표시하는 기능 추가.
- <body> 태그 바로 다음에 생성 시간을 표시하는 <div>가 추가되었습니다.
