### PR TITLE
통합 저장소 분석 시 HTML 보고서 생성 로그를 한 번만 출력

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -170,10 +170,7 @@ CoconaApp.Run((
         string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
         var totalGen = new FileGenerator(totalScores, "total", outputDir);
         totalGen.GenerateChart();
-        if (format == null || format.Length == 0 || checkFormat(format).Contains("html"))
-        {
-            totalGen.GenerateHtml();  // ✅ 마지막에 단 한 번만 HTML 출력
-        }
+        
     }
     // --user 옵션이 지정된 경우, 해당 사용자의 점수와 순위만 출력
     else if (!string.IsNullOrEmpty(singleUser) && totalScores.Count > 0)

--- a/Program.cs
+++ b/Program.cs
@@ -152,7 +152,7 @@ CoconaApp.Run((
                 if (formats.Contains("csv")) generator.GenerateCsv();
                 if (formats.Contains("text")) generator.GenerateTable();
                 if (formats.Contains("chart")) generator.GenerateChart();
-                if (formats.Contains("html")) generator.GenerateHtml();
+                if (formats.Contains("html") && repoIndex == totalRepos) generator.GenerateHtml();
                 if (showStateSummary) generator.GenerateStateSummary(collector.StateSummary);
             }
         }
@@ -170,6 +170,10 @@ CoconaApp.Run((
         string outputDir = string.IsNullOrWhiteSpace(output) ? "output" : output;
         var totalGen = new FileGenerator(totalScores, "total", outputDir);
         totalGen.GenerateChart();
+        if (format == null || format.Length == 0 || checkFormat(format).Contains("html"))
+        {
+            totalGen.GenerateHtml();  // ✅ 마지막에 단 한 번만 HTML 출력
+        }
     }
     // --user 옵션이 지정된 경우, 해당 사용자의 점수와 순위만 출력
     else if (!string.IsNullOrEmpty(singleUser) && totalScores.Count > 0)


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/422

### ISSUE_TITLE
통합 저장소 분석 시 HTML 보고서 생성 로그를 한 번만 출력

###  기준 커밋 (Specify version - commit id)
fd823eb5d1e6ce7fb25f84d79cdac672676179f2

### 변경사항
통합 저장소 분석 시, HTML 보고서 정상 생성 안내 로그는 total 분석 시 마지막에 출력하는 것으로 변경


### 🧪 테스트 방법 (선택 사항)
기존과 동일함
