### PR TITLE
chart 결과물의 막대 오른쪽 표시되는 라벨값의 정리 요청

### DIFF
--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -226,7 +226,7 @@ public class FileGenerator
             var userName = rankList.OrderBy(x => x.Score).ElementAt(i).User;
             if (_scores.TryGetValue(userName, out var userScore))
             {
-                string detailText = $"{userScore.total} (PR_fb {userScore.PR_fb} / PR_doc {userScore.PR_doc} / PR_typo {userScore.PR_typo} / IS_fb {userScore.IS_fb} / IS_doc {userScore.IS_doc})";
+                string detailText = $"{userScore.total} (P-F: {userScore.PR_fb}, D: {userScore.PR_doc}, T: {userScore.PR_typo} / I-F: {userScore.IS_fb}, D: {userScore.IS_doc})";
                 var txt = plt.Add.Text(detailText, textX, textY);
                 txt.Alignment = Alignment.MiddleLeft;
             }


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/415

### ISSUE_TITLE
chart 결과물의 막대 오른쪽 표시되는 라벨값의 정리 요청

###  기준 커밋 (Specify version - commit id)
22431f663e4bd1f63aebe55a882447b763ab72e2

### 변경사항
- 다른 저장소의 출력물과 동일하게 현재 라벨의 표기 방법으로 수정하였습니다. (P - F: x, D: x, T: x / I - F: x, D: x)
