### PR TITLE
total_chart.png 점수 누적 합산 버그 수정

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -140,7 +140,29 @@ CoconaApp.Run((
         {
             var analyzer = new ScoreAnalyzer(userActivities, idToNameMap);
             var scores = analyzer.Analyze();
-            totalScores = analyzer.TotalAnalyze(scores);
+            var repoTotal = analyzer.TotalAnalyze(scores);
+
+            foreach (var kv in repoTotal)
+            {
+                if (totalScores.ContainsKey(kv.Key))
+                {
+                    var prev = totalScores[kv.Key];
+                    var curr = kv.Value;
+                    // 모든 필드를 합산해서 새 객체 생성
+                    totalScores[kv.Key] = new UserScore(
+                        prev.PR_fb + curr.PR_fb,
+                        prev.PR_doc + curr.PR_doc,
+                        prev.PR_typo + curr.PR_typo,
+                        prev.IS_fb + curr.IS_fb,
+                        prev.IS_doc + curr.IS_doc,
+                        prev.total + curr.total
+                    );
+                }
+                else
+                {
+                    totalScores[kv.Key] = kv.Value;
+                }
+            }
 
             if (string.IsNullOrEmpty(singleUser))
             {


### PR DESCRIPTION
### ISSUE_ID
#408 

### ISSUE_TITLE
total_chart.png가 마지막 저장소의 결과로 덮어씌워짐

###  기준 커밋 (Specify version - commit id)
704df03

### 변경사항
 - 여러 저장소 분석시 total_chart.png파일에 마지막 저장소의 점수가 덮어씌워지던것을 수정했습니다.