### PR TITLE
--show-state-summary 옵션 삭제

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,8 +16,7 @@ CoconaApp.Run((
     [Option("user-info", Description = "ID→이름 매핑 JSON/CSV 파일 경로")] string? userInfoPath,
     [Option("progress", Description = "API 호출 진행률을 표시합니다.")] bool progress,
     [Option('o', Description = "출력 디렉토리 경로를 지정합니다. (default : \"output\")", ValueName = "Output directory")] string output = "output",
-    [Option("use-cache", Description = "캐시된 데이터를 사용합니다.")] bool useCache = false,
-    [Option("show-state-summary", Description = "PR/Issue 상태 요약을 표시합니다.")] bool showStateSummary = false
+    [Option("use-cache", Description = "캐시된 데이터를 사용합니다.")] bool useCache = false
 ) =>
 {
     // 캐시 디렉토리 생성
@@ -177,7 +176,6 @@ CoconaApp.Run((
                 if (formats.Contains("text")) generator.GenerateTable();
                 if (formats.Contains("chart")) generator.GenerateChart();
                 if (formats.Contains("html") && repoIndex == totalRepos) generator.GenerateHtml();
-                if (showStateSummary) generator.GenerateStateSummary(collector.StateSummary);
             }
         }
         catch (Exception ex)

--- a/Reposcore/FileGenerator.cs
+++ b/Reposcore/FileGenerator.cs
@@ -314,17 +314,6 @@ public class FileGenerator
         Console.WriteLine($"✅ 차트 생성 완료: {outputPath}");
     }
 
-    public void GenerateStateSummary(RepoStateSummary summary)
-    {
-        string filePath = Path.Combine(_folderPath, $"{_repoName}_state.txt");
-        using StreamWriter writer = new StreamWriter(filePath);
-        writer.WriteLine($"Merged PR: {summary.MergedPR}");
-        writer.WriteLine($"Unmerged PR: {summary.UnmergedPR}");
-        writer.WriteLine($"Open Issue: {summary.OpenIssue}");
-        writer.WriteLine($"Closed Issue: {summary.ClosedIssue}");
-        Console.WriteLine($"{filePath} 생성됨");
-    }
-
     public void GenerateHtml()
     {
         string filePath = Path.Combine(Path.GetDirectoryName(_folderPath)!, "index.html");


### PR DESCRIPTION
### ISSUE_ID
https://github.com/oss2025hnu/reposcore-cs/issues/400

### ISSUE_TITLE
--show-state-summary 옵션을 제거해주세요

###  기준 커밋 (Specify version - commit id)
4ace08f72c67eb22800422d698ce892c10c988ba

### 변경사항
- 옵션 선언 부분에서 showStateSummary 옵션을 제거
- FileGenerator.GenerateStateSummary() 함수 및 호출 부분 제거